### PR TITLE
Fix i/o handling in waitForRun in integration tests

### DIFF
--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -1241,10 +1241,7 @@ func waitForRun(t *testing.T, runId string, returnOnRunning bool, returnOnCancel
 	}
 
 done:
-	fmt.Println("waiting...")
 	err = cmd.Wait()
 	require.NoError(t, err, "tyger run watch failed: %s", errb.String())
-
-	fmt.Println("done")
 	return snapshot
 }


### PR DESCRIPTION
We were not properly processing lines from calls to `tyger run watch` in the integration tests