### PR TITLE
Fix proxy test instability

### DIFF
--- a/cli/integrationtest/proxy_test.go
+++ b/cli/integrationtest/proxy_test.go
@@ -54,7 +54,7 @@ timeoutSeconds: 600`
 
 	proxyOptions := proxy.ProxyOptions{}
 
-	proxyLogBuffer := bytes.Buffer{}
+	proxyLogBuffer := SyncBuffer{}
 	logger := zerolog.New(&proxyLogBuffer)
 
 	closeProxy, err := proxy.RunProxy(serviceInfo, &proxyOptions, logger)
@@ -268,4 +268,10 @@ func (s *SyncBuffer) String() string {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	return s.buffer.String()
+}
+
+func (s *SyncBuffer) Read(p []byte) (n int, err error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.buffer.Read(p)
 }


### PR DESCRIPTION
We were using a raw `bytes.Buffer` in one of the proxy tests, when we should be using a thread-safe wrapper implemented later in the file and used by the other tests. This was leading to failures like [this](https://github.com/microsoft/tyger/actions/runs/5970054998/job/16196998851)