### PR TITLE
Update CLI app ID

### DIFF
--- a/cli/internal/controlplane/auth.go
+++ b/cli/internal/controlplane/auth.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	CacheFileEnvVarName                 = "TYGER_CACHE_FILE"
-	cliClientId                         = "d81fc78a-b30f-49ee-8697-54775895e218" // this needs to be the app ID and not the identifier URI, otherwise the refresh tokens will not work.
+	cliClientId                         = "f13d0630-3b5f-4a9f-aafa-34bd3bb6062b" // this needs to be the app ID and not the identifier URI, otherwise the refresh tokens will not work.
 	userScope                           = "Read.Write"
 	servicePrincipalScope               = ".default"
 	discardTokenIfExpiringWithinSeconds = 10 * 60


### PR DESCRIPTION
In working on removing the coupling between the CLI app and its AAD app id (which is currently hardcoded in the app), I deleted and recreated the app in the eminence tenant. Of course this broke the existing clients. 

🤦‍♂️

`tyger login` is therefore broken, though not when using a service principal.

Updating the app in the CLI.