### PR TITLE
Write tags to database using `SERIALIZABLE` isolation level.

### DIFF
--- a/server/Tyger.Server/Database/LoggerExtensions.cs
+++ b/server/Tyger.Server/Database/LoggerExtensions.cs
@@ -7,4 +7,7 @@ public static partial class LoggerExtensions
 
     [LoggerMessage(1, LogLevel.Information, "Conflict when upserting codespec {name}")]
     public static partial void UpsertingCodespecConflict(this ILogger logger, string name);
+
+    [LoggerMessage(2, LogLevel.Warning, "Retrying database operation. SqlState: {sqlState}, Message: {message}")]
+    public static partial void RetryingDatabaseOperation(this ILogger logger, string? sqlState, string? message);
 }

--- a/server/Tyger.Server/Database/RepositoryWithRetry.cs
+++ b/server/Tyger.Server/Database/RepositoryWithRetry.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using Polly;
+using Tyger.Server.Model;
+using Buffer = Tyger.Server.Model.Buffer;
+
+namespace Tyger.Server.Database;
+
+public class RepositoryWithRetry : IRepository
+{
+    private readonly Repository _repository;
+    private readonly ResiliencePipeline _resiliencePipeline;
+
+    public RepositoryWithRetry(
+        ResiliencePipeline resiliencePipeline,
+        TygerDbContext context,
+        JsonSerializerOptions serializerOptions,
+        ILoggerFactory loggerFactory)
+    {
+        _repository = new(context, serializerOptions, loggerFactory.CreateLogger<Repository>());
+        _resiliencePipeline = resiliencePipeline;
+    }
+
+    public async Task<Buffer> CreateBuffer(Buffer newBuffer, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.CreateBuffer(newBuffer, cancellationToken), cancellationToken);
+    }
+
+    public async Task<Run> CreateRun(Run newRun, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.CreateRun(newRun, cancellationToken), cancellationToken);
+    }
+
+    public async Task DeleteRun(long id, CancellationToken cancellationToken)
+    {
+        await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.DeleteRun(id, cancellationToken), cancellationToken);
+    }
+
+    public async Task<Buffer?> GetBuffer(string id, string eTag, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.GetBuffer(id, eTag, cancellationToken), cancellationToken);
+    }
+
+    public async Task<(IList<Buffer>, string? nextContinuationToken)> GetBuffers(IDictionary<string, string>? tags, int limit, string? continuationToken, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.GetBuffers(tags, limit, continuationToken, cancellationToken), cancellationToken);
+    }
+
+    public async Task<Codespec?> GetCodespecAtVersion(string name, int version, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.GetCodespecAtVersion(name, version, cancellationToken), cancellationToken);
+    }
+
+    public async Task<(IList<Codespec>, string? nextContinuationToken)> GetCodespecs(int limit, string? prefix, string? continuationToken, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.GetCodespecs(limit, prefix, continuationToken, cancellationToken), cancellationToken);
+    }
+
+    public async Task<Codespec?> GetLatestCodespec(string name, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.GetLatestCodespec(name, cancellationToken), cancellationToken);
+    }
+
+    public async Task<IList<Run>> GetPageOfRunsThatNeverGotResources(CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.GetPageOfRunsThatNeverGotResources(cancellationToken), cancellationToken);
+    }
+
+    public async Task<(Run run, bool final, DateTimeOffset? logsArchivedAt)?> GetRun(long id, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.GetRun(id, cancellationToken), cancellationToken);
+    }
+
+    public async Task<(IList<(Run run, bool final)>, string? nextContinuationToken)> GetRuns(int limit, DateTimeOffset? since, string? continuationToken, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.GetRuns(limit, since, continuationToken, cancellationToken), cancellationToken);
+    }
+
+    public async Task<Buffer?> UpdateBufferById(string id, string eTag, IDictionary<string, string>? tags, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.UpdateBufferById(id, eTag, tags, cancellationToken), cancellationToken);
+    }
+
+    public async Task UpdateRun(Run run, bool? resourcesCreated = null, bool? final = null, DateTimeOffset? logsArchivedAt = null, CancellationToken cancellationToken = default)
+    {
+        await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.UpdateRun(run, resourcesCreated, final, logsArchivedAt, cancellationToken), cancellationToken);
+    }
+
+    public async Task<Codespec> UpsertCodespec(string name, Codespec newcodespec, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken => await _repository.UpsertCodespec(name, newcodespec, cancellationToken), cancellationToken);
+    }
+}

--- a/server/Tyger.Server/Tyger.Server.csproj
+++ b/server/Tyger.Server/Tyger.Server.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.3" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    <PackageReference Include="Polly.Core" Version="8.0.0" />
     <PackageReference Include="SimpleBase" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.Interactive.Async" Version="6.0.1" />


### PR DESCRIPTION
We've seen occasional integration tests failures when creating buffers with tags. The symptom was that sometimes, not all tags were recorded in the database. It turns out that this can happen when multiple requests are simultaneously creating buffers with a tag key that has not been seen before. It boils down to an "upsert" statement that does not behave the way we intended because of the default `READ COMMITTED` isolation level. In this mode, reads view a snapshot of the data before the transaction started, which could indicate that there is no existing entry in the `tag_key` table, but the the attempt to insert it will indicate that that there _is_ an entry (because another transaction added if during ours).

The simplest fix is to use `SERIALIZABLE` as the isolation level. This necessitates retrying in the case of deadlocks.  