### PR TITLE
Update certificate for the tyger test service principal

### DIFF
--- a/deploy/config/microsoft/devconfig.yml
+++ b/deploy/config/microsoft/devconfig.yml
@@ -8,7 +8,7 @@ keyVault: eminence
 testAppUri: api://tyger-test-client
 pemCertSecret:
   name: tyger-test-client-cert
-  version: 1db664a6a3c74b6f817f3d842424003d
+  version: 0fe705f5a0f94771bd38f7e997540497
 pkcs12CertSecret:
   name: tyger-test-client-cert-pkcs12
   version: f8b1b7dde7034217bf12ce4ea772b470


### PR DESCRIPTION
The certificate we were using for the test service principal for the tyger cli had expired.