### PR TITLE
Fix timeout regression

### DIFF
--- a/cli/internal/dataplane/read.go
+++ b/cli/internal/dataplane/read.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	DefaultReadDop = 32
-	MaxRetries     = 6
+	DefaultReadDop  = 32
+	MaxRetries      = 6
+	ResponseTimeout = 100 * time.Second
 )
 
 var (
@@ -59,7 +60,8 @@ func Read(ctx context.Context, uri string, outputWriter io.Writer, options ...Re
 	}
 
 	if readOptions.httpClient == nil {
-		readOptions.httpClient = httpclient.DefaultRetryableClient
+		readOptions.httpClient = httpclient.NewRetryableClient()
+		readOptions.httpClient.HTTPClient.Timeout = ResponseTimeout
 	}
 
 	httpClient := readOptions.httpClient

--- a/cli/internal/dataplane/write.go
+++ b/cli/internal/dataplane/write.go
@@ -68,7 +68,8 @@ func Write(ctx context.Context, uri string, inputReader io.Reader, options ...Wr
 
 	ctx = log.With().Str("operation", "buffer write").Logger().WithContext(ctx)
 	if writeOptions.httpClient == nil {
-		writeOptions.httpClient = httpclient.DefaultRetryableClient
+		writeOptions.httpClient = httpclient.NewRetryableClient()
+		writeOptions.httpClient.HTTPClient.Timeout = ResponseTimeout
 	}
 
 	httpClient := writeOptions.httpClient

--- a/cli/internal/httpclient/httpclient.go
+++ b/cli/internal/httpclient/httpclient.go
@@ -21,7 +21,6 @@ var DefaultRetryableClient = NewRetryableClient()
 func NewRetryableClient() *retryablehttp.Client {
 	client := retryablehttp.NewClient()
 	client.RetryMax = 6
-	client.HTTPClient.Timeout = 100 * time.Second
 
 	client.Logger = nil
 	client.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {


### PR DESCRIPTION
Fixing a regression introduced in #53 where we set a timeout for all HTTP requests, even ones that are meant to be long-running like watches and log follows. We will revert to only data-plane requests having timeouts.