### PR TITLE
Fix setup-go cache key

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -47,28 +47,15 @@ jobs:
           set -euo pipefail
           make unit-test
 
-  generate-tag:
-    runs-on: ubuntu-latest
-    outputs:
-      IMAGE_TAG: ${{ steps.tag.outputs.IMAGE_TAG }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Generate tag
-        id: tag
-        run: |
-          echo "IMAGE_TAG=$(date +'%Y%m%d%H%M%S')-$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-
   build-images:
     runs-on: ubuntu-latest
     needs:
-      - generate-tag
+      - get-config
     defaults:
       run:
         shell: bash
     env:
-      EXPLICIT_IMAGE_TAG: ${{ needs.generate-tag.outputs.IMAGE_TAG }}
+      EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
     steps:
       - name: Login into Azure
         uses: azure/login@v1
@@ -91,6 +78,7 @@ jobs:
       run:
         shell: bash
     outputs:
+      IMAGE_TAG: ${{ steps.tag.outputs.IMAGE_TAG }}
       TYGER_ENVIRONMENT_NAME: ${{ steps.set-variables.outputs.TYGER_ENVIRONMENT_NAME }}
       TYGER_URI: ${{ steps.set-variables.outputs.TYGER_URI }}
       DEVELOPER_CONFIG_BASE64: ${{ steps.set-variables.outputs.DEVELOPER_CONFIG_BASE64 }}
@@ -99,6 +87,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Generate tag
+        id: tag
+        run: |
+          echo "IMAGE_TAG=$(date +'%Y%m%d%H%M%S')-$GITHUB_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Set variables
         id: set-variables
@@ -131,7 +124,6 @@ jobs:
   up:
     runs-on: ubuntu-latest
     needs:
-      - generate-tag
       - get-config
     defaults:
       run:
@@ -139,7 +131,7 @@ jobs:
     env:
       TYGER_MIN_NODE_COUNT: "1"
       DO_NOT_BUILD_IMAGES: "true"
-      EXPLICIT_IMAGE_TAG: ${{ needs.generate-tag.outputs.IMAGE_TAG }}
+      EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
       TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
     steps:
       - name: Login into Azure
@@ -188,7 +180,7 @@ jobs:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
 
-      - name: up
+      - name: restore-scale-to-zero
         run: |
           set -euo pipefail
           make -s ensure-environment
@@ -196,7 +188,6 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     needs:
-      - generate-tag
       - get-config
       - up
     defaults:
@@ -205,7 +196,7 @@ jobs:
     env:
       TYGER_MIN_NODE_COUNT: "1"
       DO_NOT_BUILD_IMAGES: "true"
-      EXPLICIT_IMAGE_TAG: ${{ needs.generate-tag.outputs.IMAGE_TAG }}
+      EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
       TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
     steps:
       - name: Login into Azure


### PR DESCRIPTION
Building the tyger CLI is a significant bottleneck on the 2-core GitHub Actions runners. The caching capabilities of the setup-go action helps with this in a dramatic way, especially now that we build in several jobs. But I had added setup-go to jobs where we were not actually building the go code, so the cache entry ended up empty.