### PR TITLE
Support aarch64 architecture for devcontainer

### DIFF
--- a/.devcontainer/install-tools.sh
+++ b/.devcontainer/install-tools.sh
@@ -4,16 +4,17 @@ set -euo pipefail
 
 # yq
 YQ_VERSION=v4.35.1
-YQ_BINARY=yq_linux_amd64
+YQ_BINARY="yq_linux_$(dpkg --print-architecture)"
 
-wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}.tar.gz -O - |\
-  tar xz && mv ${YQ_BINARY} /usr/bin/yq
+wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}.tar.gz" -O - |\
+  tar xz && mv "${YQ_BINARY}" /usr/bin/yq
 
 # tv
 TV_VERSION="v0.7.0"
-wget "https://github.com/uzimaru0000/tv/releases/download/${TV_VERSION}/tv-x86_64-unknown-linux-gnu.zip" \
-&& unzip tv-x86_64-unknown-linux-gnu.zip \
-&& mv tv-x86_64-unknown-linux-gnu/tv /usr/bin
+TV_ARCHIVE="tv-$(uname -m)-unknown-linux-gnu"
+wget "https://github.com/uzimaru0000/tv/releases/download/${TV_VERSION}/${TV_ARCHIVE}.zip" \
+&& unzip "${TV_ARCHIVE}".zip \
+&& mv "${TV_ARCHIVE}/tv" /usr/bin
 
 # install kubelogin
 KUBELOGIN_VERSION=0.0.33

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -13,6 +13,6 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X main.version=${TYGER_VERSION}" -v -o /go/bin/dist/linux/amd64/buffer-sidecar ./cmd/buffer-sidecar \
     && upx /go/bin/dist/linux/amd64/buffer-sidecar
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0-nonroot as buffer-sidecar
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0-nonroot.20240112-amd64 as buffer-sidecar
 COPY --from=go-build /go/bin/dist/linux/amd64/buffer-sidecar /
 ENTRYPOINT ["/buffer-sidecar"]

--- a/cli/integrationtest/testconnectivity/Dockerfile
+++ b/cli/integrationtest/testconnectivity/Dockerfile
@@ -9,8 +9,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build go mod download
 COPY . .
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -tags integrationtest -ldflags="-s -w" -o /go/bin/testconnectivity ./integrationtest/testconnectivity/
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags integrationtest -ldflags="-s -w" -o /go/bin/testconnectivity ./integrationtest/testconnectivity/
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0-nonroot as testconnectivity
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0-nonroot.20240112-amd64 as testconnectivity
 COPY --from=go-build /go/bin/testconnectivity /
 ENTRYPOINT ["/testconnectivity"]

--- a/deploy/images/worker-waiter/Dockerfile
+++ b/deploy/images/worker-waiter/Dockerfile
@@ -1,2 +1,4 @@
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS worker-waiter
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0-nonroot.20240112-amd64 AS worker-waiter
+USER root
 RUN tdnf install -y kubernetes-client bind-utils
+USER nonroot

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,12 +1,12 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0.100-cbl-mariner2.0-amd64 as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.100-cbl-mariner2.0 as build
 WORKDIR /src
 
 COPY server/Tyger.Server/Tyger.Server.csproj server/Tyger.Server/
-RUN dotnet restore server/Tyger.Server/Tyger.Server.csproj
+RUN dotnet restore --arch amd64 server/Tyger.Server/Tyger.Server.csproj
 
 COPY . .
 WORKDIR /src/server/Tyger.Server
-RUN dotnet publish --no-restore -c release -o /app
+RUN dotnet publish --no-restore --arch amd64 -c release -o /app
 
 
 # final stage/image


### PR DESCRIPTION
Support running the devcontainer image on Apple silicon. Runtime images are still only amd64.