### PR TITLE
Use hosted runners when necessary

### DIFF
--- a/.github/actions/login-azure/action.yml
+++ b/.github/actions/login-azure/action.yml
@@ -1,6 +1,7 @@
 name: Log in to Azure
 description: |
   Log in to Azure either using managed identity or the azure/login action.
+
 runs:
   using: composite
   steps:
@@ -18,4 +19,3 @@ runs:
       shell: bash
       run: |
         az login --identity --username $AZURE_CLIENT_ID
-        az account show

--- a/.github/actions/login-azure/action.yml
+++ b/.github/actions/login-azure/action.yml
@@ -1,0 +1,21 @@
+name: Log in to Azure
+description: |
+  Log in to Azure either using managed identity or the azure/login action.
+runs:
+  using: composite
+  steps:
+
+    - name: Log in to Azure
+      if: ${{ env.CAN_ACCESS_SECRETS }}
+      uses: azure/login@v1
+      with:
+        client-id: ${{ env.AZURE_CLIENT_ID }}
+        tenant-id: ${{ env.AZURE_TENANT_ID }}
+        subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Log in to Azure with managed identity
+      if: ${{ ! env.CAN_ACCESS_SECRETS }}
+      shell: bash
+      run: |
+        az login --identity --username $AZURE_CLIENT_ID
+        az account show

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -40,22 +40,11 @@ jobs:
     runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUN_ON_JSON)}}
 
     steps:
-      - name: Log in to Azure
-        if: ${{ env.CAN_ACCESS_SECRETS }}
-        uses: azure/login@v1
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Log in to Azure with managed identity
-        if: ${{ ! env.CAN_ACCESS_SECRETS }}
-        run: |
-          az login --identity --username $AZURE_CLIENT_ID
-          az account show
+      - uses: ./.github/actions/login-azure
 
       - run: |
           env | sort
+          az aks list --output table
 
   # unit-tests-and-format:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -22,8 +22,8 @@ env:
 jobs:
 
   test:
-    # runs-on: ${{ fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]')}}
-    runs-on: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]') || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]')}}
+    # runs-on: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]') || 'ubuntu-latest' }}
 
     steps:
       - run: |

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,7 +17,6 @@ env:
   AZURE_SUBSCRIPTION_ID: 87d8acb3-5176-4651-b457-6ab9cefd8e3d
 
   CAN_ACCESS_SECRETS: ${{ secrets.CAN_ACCESS_SECRETS }}
-  AZURE_RUN_ON_JSON: ${{ secrets.CAN_ACCESS_SECRETS && fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]') || 'ubuntu-latest'}}
 
 jobs:
   test-azure-needs-hosted-runner:
@@ -54,6 +53,9 @@ jobs:
         run: |
           az login --identity --username $AZURE_CLIENT_ID
           az account show
+
+      - run: |
+          env | sort
 
   # unit-tests-and-format:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - id: set-vars
         run: |
-          if [[ -z "$CAN_ACCESS_SECRETS" ]]; then
+          if [[ -n "${CAN_ACCESS_SECRETS:-}" ]]; then
             AZURE_RUN_ON_JSON='"ubuntu-latest"'
           else
             AZURE_RUN_ON_JSON='["self-hosted", "1ES.Pool=tyger-gh-1es"]'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -40,6 +40,12 @@ jobs:
     runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUN_ON_JSON)}}
 
     steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - uses: ./.github/actions/login-azure
 
       - run: |

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -16,487 +16,499 @@ env:
   AZURE_TENANT_ID: 72f988bf-86f1-41af-91ab-2d7cd011db47
   AZURE_SUBSCRIPTION_ID: 87d8acb3-5176-4651-b457-6ab9cefd8e3d
 
+  IS_FORK: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
+  AZURE_POOL_JSON: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && '["self-hosted", "1ES.Pool=tyger-gh-1es"]' || 'ubuntu-latest' }}
+
 jobs:
 
-  unit-tests-and-format:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      TYGER_MIN_NODE_COUNT: "1"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: cli/go.mod
-          cache-dependency-path: cli/go.sum
-
-      - uses: actions/setup-dotnet@v3
-        with:
-          global-json-file: server/global.json
-
-      - name: Build and Verify format
-        run: |
-          set -euo pipefail
-          make restore
-          make verify-format
-          make install-cli
-
-      - name: Run unit tests
-        run: |
-          set -euo pipefail
-          make unit-test
-
-      - name: Generate NOTICE.txt
-        run: |
-          set -euo pipefail
-
-          scripts/generate-notice.sh
-          if [[ `git status --porcelain` ]]; then
-            git diff
-            echo "ERROR: NOTICE.txt needs to be regenerated using scripts/generate-notice.sh"
-            exit 1
-          fi
-
-      - name: Check copyright headers
-        run: |
-          set -euo pipefail
-
-          scripts/add-copyright-headers.sh
-          if [[ `git status --porcelain` ]]; then
-            git diff
-            echo "ERROR: update copyright headers using scripts/add-cpopyright-headers.sh"
-            exit 1
-          fi
-
-  build-images:
-    runs-on: ubuntu-latest
-    needs:
-      - get-config
-    defaults:
-      run:
-        shell: bash
-    env:
-      EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
-    steps:
-      - name: Log in to Azure
-        uses: azure/login@v1
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: build images
-        run: |
-          set -eo pipefail
-          make -j 4 docker-build
-
-  get-config:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    outputs:
-      IMAGE_TAG: ${{ steps.tag.outputs.IMAGE_TAG }}
-      TYGER_ENVIRONMENT_NAME: ${{ steps.set-variables.outputs.TYGER_ENVIRONMENT_NAME }}
-      TYGER_URI: ${{ steps.set-variables.outputs.TYGER_URI }}
-      DEVELOPER_CONFIG_BASE64: ${{ steps.set-variables.outputs.DEVELOPER_CONFIG_BASE64 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Generate tag
-        id: tag
-        run: |
-          echo "IMAGE_TAG=$(date +'%Y%m%d%H%M%S')-$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-
-      - name: Set variables
-        id: set-variables
-        run: |
-          set -eo pipefail
-
-          event_name="${{ github.event_name }}"
-          if [ "$event_name" == "pull_request" ]; then
-            environment_name="tyger-gpr${{ github.event.pull_request.number }}"
-          else
-            environment_name="tygerwestus2"
-          fi
-
-          export TYGER_ENVIRONMENT_NAME="${environment_name}"
-
-          tyger_uri=$(make -s get-tyger-uri)
-          echo "TYGER_URI=$tyger_uri" >> "$GITHUB_OUTPUT"
-
-          echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_OUTPUT"
-          echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_ENV"
-
-          # GitHub Actions thinks this holds a secret, which prevents us from using
-          # it as an output variable. So we base64 encode it as a workaround.
-          # There is no secret in this value.
-
-          developer_config_base64=$(scripts/get-config.sh --dev -o json | jq -c | base64 -w 0)
-          echo "DEVELOPER_CONFIG_BASE64=$developer_config_base64" >> "$GITHUB_OUTPUT"
-          echo "DEVELOPER_CONFIG_BASE64=$developer_config_base64" >> "$GITHUB_ENV"
-
-  up:
-    runs-on: ubuntu-latest
-    needs:
-      - get-config
-    defaults:
-      run:
-        shell: bash
-    env:
-      TYGER_MIN_NODE_COUNT: "1"
-      DO_NOT_BUILD_IMAGES: "true"
-      EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
-      TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
-    steps:
-      - name: Log in to Azure
-        uses: azure/login@v1
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: cli/go.mod
-          cache-dependency-path: cli/go.sum
-
-      - name: up
-        run: |
-          set -euo pipefail
-          make -s up INSTALL_CLOUD=true
-          make -s migrate
-
-  restore-scale-to-zero:
-    runs-on: ubuntu-latest
-    needs:
-      - up
-      - get-config
-    defaults:
-      run:
-        shell: bash
-    env:
-      TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
-    steps:
-      - name: Log in to Azure
-        uses: azure/login@v1
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: cli/go.mod
-          cache-dependency-path: cli/go.sum
-
-      - name: restore-scale-to-zero
-        run: |
-          set -euo pipefail
-          make -s ensure-environment
-
-  integration-tests:
-    runs-on: ubuntu-latest
-    needs:
-      - get-config
-      - up
-    defaults:
-      run:
-        shell: bash
-    env:
-      TYGER_MIN_NODE_COUNT: "1"
-      DO_NOT_BUILD_IMAGES: "true"
-      EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
-      TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
-    steps:
-      - name: Log in to Azure
-        uses: azure/login@v1
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: cli/go.mod
-          cache-dependency-path: cli/go.sum
-
-      - name: Deploy and test
-        run: |
-          set -euo pipefail
-          make -s integration-test-no-up
-
-  publish-official-images:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Log in to Azure
-        uses: azure/login@v1
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Publish official images
-        run: |
-          set -euo pipefail
-          make publish-official-images
-
-  build-windows-binaries:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: cli/go.mod
-          # use a different cache key for windows builds
-          cache-dependency-path: |
-            cli/go.sum
-            cli/go.mod
-
-      - name: Build Windows Binaries
-        run: |
-          set -eo pipefail
-
-          export CGO_ENABLED=1
-          export GOOS=windows
-          export GOARCH=amd64
-
-          make install-cli
-
-          destination="${GITHUB_WORKSPACE}/windows-cli-tools"
-          mkdir -p "$destination"
-          cp -a "$(go env GOPATH)/bin/$(go env GOOS)_$(go env GOARCH)/." "$destination"
-
-      - name: Archive windows-cli-tools
-        uses: actions/upload-artifact@v3
-        with:
-          name: windows-cli-tools
-          path: windows-cli-tools
-
-  windows-smoke-tests:
-    runs-on: windows-latest
-    needs:
-      - get-config
-      - build-windows-binaries
-      - up
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: windows-cli-tools
-          path: windows-cli-tools
-
-      - name: Log in to Azure
-        uses: azure/login@v1
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-          enable-AzPSSession: true
-
-      - name: Run smoke tests
-        env:
-          DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
-          TYGER_URI: ${{ needs.get-config.outputs.TYGER_URI }}
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          Set-StrictMode -Version Latest
-
-          $env:PATH = "$env:GITHUB_WORKSPACE\windows-cli-tools;" + $env:PATH
-
-          $developerConfig = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:DEVELOPER_CONFIG_BASE64)) | ConvertFrom-Json
-
-          $servicePrincipal = $developerConfig.testAppUri
-          $keyVaultName = $developerConfig.keyVault
-          $certificateName = $developerConfig.pkcs12CertSecret.name
-          $certificateVersion = $developerConfig.pkcs12CertSecret.version
-
-          # Run tests
-          .\scripts\Test-CertificateLoginOnWindows.ps1 `
-            -ServerUri $env:TYGER_URI `
-            -ServicePrincipal $servicePrincipal `
-            -KeyVaultName $keyVaultName `
-            -CertificateName $certificateName `
-            -CertificateVersion $certificateVersion
-
-  codeql:
-    runs-on: ubuntu-latest
-    if: github.repository == 'microsoft/tyger'
-    defaults:
-      run:
-        shell: bash
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'csharp', 'go' ]
+  test:
+    # runs-on: ${{ fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]')}}
+    runs-on: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]') || 'ubuntu-latest' }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - run: |
+          az login --identity
+          az account show
 
-      - uses: actions/setup-go@v4
-        if: matrix.language == 'go'
-        with:
-          go-version-file: cli/go.mod
-          cache-dependency-path: cli/go.sum
+  # unit-tests-and-format:
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   env:
+  #     TYGER_MIN_NODE_COUNT: "1"
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v3
-        with:
-          global-json-file: server/global.json
+  #     - uses: actions/setup-go@v4
+  #       with:
+  #         go-version-file: cli/go.mod
+  #         cache-dependency-path: cli/go.sum
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: ${{ matrix.language }}
+  #     - uses: actions/setup-dotnet@v3
+  #       with:
+  #         global-json-file: server/global.json
 
-      - name: "Build"
-        run: |
-          set -euo pipefail
-          make -s build-${{ matrix.language }}
+  #     - name: Build and Verify format
+  #       run: |
+  #         set -euo pipefail
+  #         make restore
+  #         make verify-format
+  #         make install-cli
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
-        with:
-          category: "/language:${{matrix.language}}"
+  #     - name: Run unit tests
+  #       run: |
+  #         set -euo pipefail
+  #         make unit-test
 
-  publishDocs:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'microsoft/tyger'
-    needs:
-      - unit-tests-and-format
-      - integration-tests
-      - get-config
-      - windows-smoke-tests
+  #     - name: Generate NOTICE.txt
+  #       run: |
+  #         set -euo pipefail
 
-    runs-on: ubuntu-latest
+  #         scripts/generate-notice.sh
+  #         if [[ `git status --porcelain` ]]; then
+  #           git diff
+  #           echo "ERROR: NOTICE.txt needs to be regenerated using scripts/generate-notice.sh"
+  #           exit 1
+  #         fi
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  #     - name: Check copyright headers
+  #       run: |
+  #         set -euo pipefail
 
-    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
+  #         scripts/add-copyright-headers.sh
+  #         if [[ `git status --porcelain` ]]; then
+  #           git diff
+  #           echo "ERROR: update copyright headers using scripts/add-cpopyright-headers.sh"
+  #           exit 1
+  #         fi
 
-    # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-    # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-    concurrency:
-      group: "pages"
-      cancel-in-progress: false
+  # build-images:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - get-config
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   env:
+  #     EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
+  #   steps:
+  #     - name: Log in to Azure
+  #       uses: azure/login@v1
+  #       with:
+  #         client-id: ${{ env.AZURE_CLIENT_ID }}
+  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
+  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Build static page
-        run: |
-            cd docs
-            npm install
-            npm run docs:build
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
-        with:
-          # Upload entire repository
-          path: 'docs/.vitepress/dist'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+  #     - name: build images
+  #       run: |
+  #         set -eo pipefail
+  #         make -j 4 docker-build
 
-  release:
-    if: startsWith(github.ref, 'refs/tags/')
-    needs:
-      - unit-tests-and-format
-      - integration-tests
-      - get-config
-      - windows-smoke-tests
-    env:
-      DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+  # get-config:
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   outputs:
+  #     IMAGE_TAG: ${{ steps.tag.outputs.IMAGE_TAG }}
+  #     TYGER_ENVIRONMENT_NAME: ${{ steps.set-variables.outputs.TYGER_ENVIRONMENT_NAME }}
+  #     TYGER_URI: ${{ steps.set-variables.outputs.TYGER_URI }}
+  #     DEVELOPER_CONFIG_BASE64: ${{ steps.set-variables.outputs.DEVELOPER_CONFIG_BASE64 }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: cli/go.mod
-          cache-dependency-path: cli/go.sum
+  #     - name: Generate tag
+  #       id: tag
+  #       run: |
+  #         echo "IMAGE_TAG=$(date +'%Y%m%d%H%M%S')-$GITHUB_SHA" >> "$GITHUB_OUTPUT"
 
-      - name: get container registry
-        run: |
-          set -euo pipefail
-          official_container_registry=$(echo "$DEVELOPER_CONFIG_BASE64" | base64 -d | jq -r '.officialContainerRegistry.fqdn')
-          echo "OFFICIAL_CONTAINER_REGISTRY=$(echo $official_container_registry)" >> $GITHUB_ENV
+  #     - name: Set variables
+  #       id: set-variables
+  #       run: |
+  #         set -eo pipefail
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          version: v1.21.2
-          workdir: cli
-          args: release --clean
+  #         event_name="${{ github.event_name }}"
+  #         if [ "$event_name" == "pull_request" ]; then
+  #           environment_name="tyger-gpr${{ github.event.pull_request.number }}"
+  #         else
+  #           environment_name="tygerwestus2"
+  #         fi
+
+  #         export TYGER_ENVIRONMENT_NAME="${environment_name}"
+
+  #         tyger_uri=$(make -s get-tyger-uri)
+  #         echo "TYGER_URI=$tyger_uri" >> "$GITHUB_OUTPUT"
+
+  #         echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_OUTPUT"
+  #         echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_ENV"
+
+  #         # GitHub Actions thinks this holds a secret, which prevents us from using
+  #         # it as an output variable. So we base64 encode it as a workaround.
+  #         # There is no secret in this value.
+
+  #         developer_config_base64=$(scripts/get-config.sh --dev -o json | jq -c | base64 -w 0)
+  #         echo "DEVELOPER_CONFIG_BASE64=$developer_config_base64" >> "$GITHUB_OUTPUT"
+  #         echo "DEVELOPER_CONFIG_BASE64=$developer_config_base64" >> "$GITHUB_ENV"
+
+  # up:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - get-config
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   env:
+  #     TYGER_MIN_NODE_COUNT: "1"
+  #     DO_NOT_BUILD_IMAGES: "true"
+  #     EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
+  #     TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
+  #   steps:
+  #     - name: Log in to Azure
+  #       uses: azure/login@v1
+  #       with:
+  #         client-id: ${{ env.AZURE_CLIENT_ID }}
+  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
+  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: actions/setup-go@v4
+  #       with:
+  #         go-version-file: cli/go.mod
+  #         cache-dependency-path: cli/go.sum
+
+  #     - name: up
+  #       run: |
+  #         set -euo pipefail
+  #         make -s up INSTALL_CLOUD=true
+  #         make -s migrate
+
+  # restore-scale-to-zero:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - up
+  #     - get-config
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   env:
+  #     TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
+  #   steps:
+  #     - name: Log in to Azure
+  #       uses: azure/login@v1
+  #       with:
+  #         client-id: ${{ env.AZURE_CLIENT_ID }}
+  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
+  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: actions/setup-go@v4
+  #       with:
+  #         go-version-file: cli/go.mod
+  #         cache-dependency-path: cli/go.sum
+
+  #     - name: restore-scale-to-zero
+  #       run: |
+  #         set -euo pipefail
+  #         make -s ensure-environment
+
+  # integration-tests:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - get-config
+  #     - up
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   env:
+  #     TYGER_MIN_NODE_COUNT: "1"
+  #     DO_NOT_BUILD_IMAGES: "true"
+  #     EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
+  #     TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
+  #   steps:
+  #     - name: Log in to Azure
+  #       uses: azure/login@v1
+  #       with:
+  #         client-id: ${{ env.AZURE_CLIENT_ID }}
+  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
+  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: actions/setup-go@v4
+  #       with:
+  #         go-version-file: cli/go.mod
+  #         cache-dependency-path: cli/go.sum
+
+  #     - name: Deploy and test
+  #       run: |
+  #         set -euo pipefail
+  #         make -s integration-test-no-up
+
+  # publish-official-images:
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   steps:
+  #     - name: Log in to Azure
+  #       uses: azure/login@v1
+  #       with:
+  #         client-id: ${{ env.AZURE_CLIENT_ID }}
+  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
+  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Publish official images
+  #       run: |
+  #         set -euo pipefail
+  #         make publish-official-images
+
+  # build-windows-binaries:
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: actions/setup-go@v4
+  #       with:
+  #         go-version-file: cli/go.mod
+  #         # use a different cache key for windows builds
+  #         cache-dependency-path: |
+  #           cli/go.sum
+  #           cli/go.mod
+
+  #     - name: Build Windows Binaries
+  #       run: |
+  #         set -eo pipefail
+
+  #         export CGO_ENABLED=1
+  #         export GOOS=windows
+  #         export GOARCH=amd64
+
+  #         make install-cli
+
+  #         destination="${GITHUB_WORKSPACE}/windows-cli-tools"
+  #         mkdir -p "$destination"
+  #         cp -a "$(go env GOPATH)/bin/$(go env GOOS)_$(go env GOARCH)/." "$destination"
+
+  #     - name: Archive windows-cli-tools
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: windows-cli-tools
+  #         path: windows-cli-tools
+
+  # windows-smoke-tests:
+  #   runs-on: windows-latest
+  #   needs:
+  #     - get-config
+  #     - build-windows-binaries
+  #     - up
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: windows-cli-tools
+  #         path: windows-cli-tools
+
+  #     - name: Log in to Azure
+  #       uses: azure/login@v1
+  #       with:
+  #         client-id: ${{ env.AZURE_CLIENT_ID }}
+  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
+  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+  #         enable-AzPSSession: true
+
+  #     - name: Run smoke tests
+  #       env:
+  #         DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
+  #         TYGER_URI: ${{ needs.get-config.outputs.TYGER_URI }}
+  #       shell: pwsh
+  #       run: |
+  #         $ErrorActionPreference = "Stop"
+  #         Set-StrictMode -Version Latest
+
+  #         $env:PATH = "$env:GITHUB_WORKSPACE\windows-cli-tools;" + $env:PATH
+
+  #         $developerConfig = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:DEVELOPER_CONFIG_BASE64)) | ConvertFrom-Json
+
+  #         $servicePrincipal = $developerConfig.testAppUri
+  #         $keyVaultName = $developerConfig.keyVault
+  #         $certificateName = $developerConfig.pkcs12CertSecret.name
+  #         $certificateVersion = $developerConfig.pkcs12CertSecret.version
+
+  #         # Run tests
+  #         .\scripts\Test-CertificateLoginOnWindows.ps1 `
+  #           -ServerUri $env:TYGER_URI `
+  #           -ServicePrincipal $servicePrincipal `
+  #           -KeyVaultName $keyVaultName `
+  #           -CertificateName $certificateName `
+  #           -CertificateVersion $certificateVersion
+
+  # codeql:
+  #   runs-on: ubuntu-latest
+  #   if: github.repository == 'microsoft/tyger'
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     security-events: write
+
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       language: [ 'csharp', 'go' ]
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: actions/setup-go@v4
+  #       if: matrix.language == 'go'
+  #       with:
+  #         go-version-file: cli/go.mod
+  #         cache-dependency-path: cli/go.sum
+
+  #     - uses: actions/setup-dotnet@v3
+  #       with:
+  #         global-json-file: server/global.json
+
+  #     - name: Initialize CodeQL
+  #       uses: github/codeql-action/init@v2
+  #       with:
+  #         languages: ${{ matrix.language }}
+
+  #     - name: "Build"
+  #       run: |
+  #         set -euo pipefail
+  #         make -s build-${{ matrix.language }}
+
+  #     - name: Perform CodeQL Analysis
+  #       uses: github/codeql-action/analyze@v2
+  #       with:
+  #         category: "/language:${{matrix.language}}"
+
+  # publishDocs:
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'microsoft/tyger'
+  #   needs:
+  #     - unit-tests-and-format
+  #     - integration-tests
+  #     - get-config
+  #     - windows-smoke-tests
+
+  #   runs-on: ubuntu-latest
+
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+
+  #   # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+  #   permissions:
+  #     contents: read
+  #     pages: write
+  #     id-token: write
+
+  #   # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+  #   # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+  #   concurrency:
+  #     group: "pages"
+  #     cancel-in-progress: false
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Build static page
+  #       run: |
+  #           cd docs
+  #           npm install
+  #           npm run docs:build
+  #     - name: Setup Pages
+  #       uses: actions/configure-pages@v3
+  #     - name: Upload artifact
+  #       uses: actions/upload-pages-artifact@v2
+  #       with:
+  #         # Upload entire repository
+  #         path: 'docs/.vitepress/dist'
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v2
+
+  # release:
+  #   if: startsWith(github.ref, 'refs/tags/')
+  #   needs:
+  #     - unit-tests-and-format
+  #     - integration-tests
+  #     - get-config
+  #     - windows-smoke-tests
+  #   env:
+  #     DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
+  #   permissions:
+  #     contents: write
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: actions/setup-go@v4
+  #       with:
+  #         go-version-file: cli/go.mod
+  #         cache-dependency-path: cli/go.sum
+
+  #     - name: get container registry
+  #       run: |
+  #         set -euo pipefail
+  #         official_container_registry=$(echo "$DEVELOPER_CONFIG_BASE64" | base64 -d | jq -r '.officialContainerRegistry.fqdn')
+  #         echo "OFFICIAL_CONTAINER_REGISTRY=$(echo $official_container_registry)" >> $GITHUB_ENV
+
+  #     - name: Run GoReleaser
+  #       uses: goreleaser/goreleaser-action@v5
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         version: v1.21.2
+  #         workdir: cli
+  #         args: release --clean

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -12,22 +12,47 @@ permissions:
   contents: read
 
 env:
-  AZURE_CLIENT_ID: 56ab98d2-93dd-4d44-88be-c932fa3bc974
+  AZURE_CLIENT_ID: 789b8572-1fae-4a5f-b376-6d9d14651245
   AZURE_TENANT_ID: 72f988bf-86f1-41af-91ab-2d7cd011db47
   AZURE_SUBSCRIPTION_ID: 87d8acb3-5176-4651-b457-6ab9cefd8e3d
 
-  IS_FORK: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
-  AZURE_POOL_JSON: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && '["self-hosted", "1ES.Pool=tyger-gh-1es"]' || 'ubuntu-latest' }}
+  CAN_ACCESS_SECRETS: ${{ secrets.CAN_ACCESS_SECRETS }}
+  AZURE_RUN_ON_JSON: ${{ secrets.CAN_ACCESS_SECRETS && fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]') || 'ubuntu-latest'}}
 
 jobs:
+  test-azure-needs-hosted-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      AZURE_RUN_ON_JSON: ${{ steps.set-vars.outputs.AZURE_RUN_ON_JSON }}
+    steps:
+      - id: set-vars
+        run: |
+          if [[ -z "$CAN_ACCESS_SECRETS" ]]; then
+            AZURE_RUN_ON_JSON='"ubuntu-latest"'
+          else
+            AZURE_RUN_ON_JSON='["self-hosted", "1ES.Pool=tyger-gh-1es"]'
+          fi
+
+          echo "AZURE_RUN_ON_JSON=$AZURE_RUN_ON_JSON" >> "$GITHUB_OUTPUT"
 
   test:
-    runs-on: ${{ fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]')}}
-    # runs-on: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && fromJSON('["self-hosted", "1ES.Pool=tyger-gh-1es"]') || 'ubuntu-latest' }}
+    needs:
+      - test-azure-needs-hosted-runner
+    runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUN_ON_JSON)}}
 
     steps:
-      - run: |
-          az login --identity --username 789b8572-1fae-4a5f-b376-6d9d14651245
+      - name: Log in to Azure
+        if: ${{ env.CAN_ACCESS_SECRETS }}
+        uses: azure/login@v1
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to Azure with managed identity
+        if: ${{ ! env.CAN_ACCESS_SECRETS }}
+        run: |
+          az login --identity --username $AZURE_CLIENT_ID
           az account show
 
   # unit-tests-and-format:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - run: |
-          az login --identity
+          az login --identity --username 789b8572-1fae-4a5f-b376-6d9d14651245 --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --subscription 87d8acb3-5176-4651-b457-6ab9cefd8e3d
           az account show
 
   # unit-tests-and-format:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -22,22 +22,164 @@ jobs:
   test-azure-needs-hosted-runner:
     runs-on: ubuntu-latest
     outputs:
-      AZURE_RUN_ON_JSON: ${{ steps.set-vars.outputs.AZURE_RUN_ON_JSON }}
+      AZURE_RUNS_ON_JSON: ${{ steps.set-vars.outputs.AZURE_RUNS_ON_JSON }}
+      AZURE_RUNS_ON_WINDOWS_JSON: ${{ steps.set-vars.outputs.AZURE_RUNS_ON_WINDOWS_JSON }}
     steps:
       - id: set-vars
         run: |
           if [[ -n "${CAN_ACCESS_SECRETS:-}" ]]; then
-            AZURE_RUN_ON_JSON='"ubuntu-latest"'
+            AZURE_RUNS_ON_JSON='"ubuntu-latest"'
+            AZURE_RUNS_ON_WINDOWS_JSON='"windows-latest"'
           else
-            AZURE_RUN_ON_JSON='["self-hosted", "1ES.Pool=tyger-gh-1es"]'
+            AZURE_RUNS_ON_JSON='["self-hosted", "1ES.Pool=tyger-gh-1es"]'
+
           fi
 
-          echo "AZURE_RUN_ON_JSON=$AZURE_RUN_ON_JSON" >> "$GITHUB_OUTPUT"
+          echo "AZURE_RUNS_ON_JSON=$AZURE_RUNS_ON_JSON" >> "$GITHUB_OUTPUT"
 
-  test:
+
+  unit-tests-and-format:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      TYGER_MIN_NODE_COUNT: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - uses: actions/setup-dotnet@v3
+        with:
+          global-json-file: server/global.json
+
+      - name: Build and Verify format
+        run: |
+          set -euo pipefail
+          make restore
+          make verify-format
+          make install-cli
+
+      - name: Run unit tests
+        run: |
+          set -euo pipefail
+          make unit-test
+
+      - name: Generate NOTICE.txt
+        run: |
+          set -euo pipefail
+
+          scripts/generate-notice.sh
+          if [[ `git status --porcelain` ]]; then
+            git diff
+            echo "ERROR: NOTICE.txt needs to be regenerated using scripts/generate-notice.sh"
+            exit 1
+          fi
+
+      - name: Check copyright headers
+        run: |
+          set -euo pipefail
+
+          scripts/add-copyright-headers.sh
+          if [[ `git status --porcelain` ]]; then
+            git diff
+            echo "ERROR: update copyright headers using scripts/add-cpopyright-headers.sh"
+            exit 1
+          fi
+
+  build-images:
     needs:
       - test-azure-needs-hosted-runner
-    runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUN_ON_JSON)}}
+      - get-config
+
+    runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUNS_ON_JSON)}}
+
+    env:
+      EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Azure
+        uses: ./.github/actions/login-azure
+
+      - name: build images
+        run: |
+          set -eo pipefail
+          make -j 4 docker-build
+
+  get-config:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      IMAGE_TAG: ${{ steps.tag.outputs.IMAGE_TAG }}
+      TYGER_ENVIRONMENT_NAME: ${{ steps.set-variables.outputs.TYGER_ENVIRONMENT_NAME }}
+      TYGER_URI: ${{ steps.set-variables.outputs.TYGER_URI }}
+      DEVELOPER_CONFIG_BASE64: ${{ steps.set-variables.outputs.DEVELOPER_CONFIG_BASE64 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Generate tag
+        id: tag
+        run: |
+          echo "IMAGE_TAG=$(date +'%Y%m%d%H%M%S')-$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Set variables
+        id: set-variables
+        run: |
+          set -eo pipefail
+
+          event_name="${{ github.event_name }}"
+          if [ "$event_name" == "pull_request" ]; then
+            environment_name="tyger-gpr${{ github.event.pull_request.number }}"
+          else
+            environment_name="tygerwestus2"
+          fi
+
+          export TYGER_ENVIRONMENT_NAME="${environment_name}"
+
+          tyger_uri=$(make -s get-tyger-uri)
+          echo "TYGER_URI=$tyger_uri" >> "$GITHUB_OUTPUT"
+
+          echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_OUTPUT"
+          echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_ENV"
+
+          # GitHub Actions thinks this holds a secret, which prevents us from using
+          # it as an output variable. So we base64 encode it as a workaround.
+          # There is no secret in this value.
+
+          developer_config_base64=$(scripts/get-config.sh --dev -o json | jq -c | base64 -w 0)
+          echo "DEVELOPER_CONFIG_BASE64=$developer_config_base64" >> "$GITHUB_OUTPUT"
+          echo "DEVELOPER_CONFIG_BASE64=$developer_config_base64" >> "$GITHUB_ENV"
+
+  up:
+    needs:
+      - test-azure-needs-hosted-runner
+      - get-config
+    runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUNS_ON_JSON)}}
+    defaults:
+      run:
+        shell: bash
+    env:
+      TYGER_MIN_NODE_COUNT: "1"
+      DO_NOT_BUILD_IMAGES: "true"
+      EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
+      TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
 
     steps:
 
@@ -46,491 +188,316 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/login-azure
-
-      - run: |
-          env | sort
-          az aks list --output table
-
-  # unit-tests-and-format:
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   env:
-  #     TYGER_MIN_NODE_COUNT: "1"
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - uses: actions/setup-go@v4
-  #       with:
-  #         go-version-file: cli/go.mod
-  #         cache-dependency-path: cli/go.sum
-
-  #     - uses: actions/setup-dotnet@v3
-  #       with:
-  #         global-json-file: server/global.json
-
-  #     - name: Build and Verify format
-  #       run: |
-  #         set -euo pipefail
-  #         make restore
-  #         make verify-format
-  #         make install-cli
-
-  #     - name: Run unit tests
-  #       run: |
-  #         set -euo pipefail
-  #         make unit-test
-
-  #     - name: Generate NOTICE.txt
-  #       run: |
-  #         set -euo pipefail
-
-  #         scripts/generate-notice.sh
-  #         if [[ `git status --porcelain` ]]; then
-  #           git diff
-  #           echo "ERROR: NOTICE.txt needs to be regenerated using scripts/generate-notice.sh"
-  #           exit 1
-  #         fi
-
-  #     - name: Check copyright headers
-  #       run: |
-  #         set -euo pipefail
-
-  #         scripts/add-copyright-headers.sh
-  #         if [[ `git status --porcelain` ]]; then
-  #           git diff
-  #           echo "ERROR: update copyright headers using scripts/add-cpopyright-headers.sh"
-  #           exit 1
-  #         fi
-
-  # build-images:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - get-config
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   env:
-  #     EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
-  #   steps:
-  #     - name: Log in to Azure
-  #       uses: azure/login@v1
-  #       with:
-  #         client-id: ${{ env.AZURE_CLIENT_ID }}
-  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
-  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: build images
-  #       run: |
-  #         set -eo pipefail
-  #         make -j 4 docker-build
-
-  # get-config:
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   outputs:
-  #     IMAGE_TAG: ${{ steps.tag.outputs.IMAGE_TAG }}
-  #     TYGER_ENVIRONMENT_NAME: ${{ steps.set-variables.outputs.TYGER_ENVIRONMENT_NAME }}
-  #     TYGER_URI: ${{ steps.set-variables.outputs.TYGER_URI }}
-  #     DEVELOPER_CONFIG_BASE64: ${{ steps.set-variables.outputs.DEVELOPER_CONFIG_BASE64 }}
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Generate tag
-  #       id: tag
-  #       run: |
-  #         echo "IMAGE_TAG=$(date +'%Y%m%d%H%M%S')-$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-
-  #     - name: Set variables
-  #       id: set-variables
-  #       run: |
-  #         set -eo pipefail
-
-  #         event_name="${{ github.event_name }}"
-  #         if [ "$event_name" == "pull_request" ]; then
-  #           environment_name="tyger-gpr${{ github.event.pull_request.number }}"
-  #         else
-  #           environment_name="tygerwestus2"
-  #         fi
-
-  #         export TYGER_ENVIRONMENT_NAME="${environment_name}"
-
-  #         tyger_uri=$(make -s get-tyger-uri)
-  #         echo "TYGER_URI=$tyger_uri" >> "$GITHUB_OUTPUT"
-
-  #         echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_OUTPUT"
-  #         echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_ENV"
-
-  #         # GitHub Actions thinks this holds a secret, which prevents us from using
-  #         # it as an output variable. So we base64 encode it as a workaround.
-  #         # There is no secret in this value.
-
-  #         developer_config_base64=$(scripts/get-config.sh --dev -o json | jq -c | base64 -w 0)
-  #         echo "DEVELOPER_CONFIG_BASE64=$developer_config_base64" >> "$GITHUB_OUTPUT"
-  #         echo "DEVELOPER_CONFIG_BASE64=$developer_config_base64" >> "$GITHUB_ENV"
-
-  # up:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - get-config
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   env:
-  #     TYGER_MIN_NODE_COUNT: "1"
-  #     DO_NOT_BUILD_IMAGES: "true"
-  #     EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
-  #     TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
-  #   steps:
-  #     - name: Log in to Azure
-  #       uses: azure/login@v1
-  #       with:
-  #         client-id: ${{ env.AZURE_CLIENT_ID }}
-  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
-  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - uses: actions/setup-go@v4
-  #       with:
-  #         go-version-file: cli/go.mod
-  #         cache-dependency-path: cli/go.sum
-
-  #     - name: up
-  #       run: |
-  #         set -euo pipefail
-  #         make -s up INSTALL_CLOUD=true
-  #         make -s migrate
-
-  # restore-scale-to-zero:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - up
-  #     - get-config
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   env:
-  #     TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
-  #   steps:
-  #     - name: Log in to Azure
-  #       uses: azure/login@v1
-  #       with:
-  #         client-id: ${{ env.AZURE_CLIENT_ID }}
-  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
-  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - uses: actions/setup-go@v4
-  #       with:
-  #         go-version-file: cli/go.mod
-  #         cache-dependency-path: cli/go.sum
-
-  #     - name: restore-scale-to-zero
-  #       run: |
-  #         set -euo pipefail
-  #         make -s ensure-environment
-
-  # integration-tests:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - get-config
-  #     - up
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   env:
-  #     TYGER_MIN_NODE_COUNT: "1"
-  #     DO_NOT_BUILD_IMAGES: "true"
-  #     EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
-  #     TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
-  #   steps:
-  #     - name: Log in to Azure
-  #       uses: azure/login@v1
-  #       with:
-  #         client-id: ${{ env.AZURE_CLIENT_ID }}
-  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
-  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - uses: actions/setup-go@v4
-  #       with:
-  #         go-version-file: cli/go.mod
-  #         cache-dependency-path: cli/go.sum
-
-  #     - name: Deploy and test
-  #       run: |
-  #         set -euo pipefail
-  #         make -s integration-test-no-up
-
-  # publish-official-images:
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   steps:
-  #     - name: Log in to Azure
-  #       uses: azure/login@v1
-  #       with:
-  #         client-id: ${{ env.AZURE_CLIENT_ID }}
-  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
-  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Publish official images
-  #       run: |
-  #         set -euo pipefail
-  #         make publish-official-images
-
-  # build-windows-binaries:
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - uses: actions/setup-go@v4
-  #       with:
-  #         go-version-file: cli/go.mod
-  #         # use a different cache key for windows builds
-  #         cache-dependency-path: |
-  #           cli/go.sum
-  #           cli/go.mod
-
-  #     - name: Build Windows Binaries
-  #       run: |
-  #         set -eo pipefail
-
-  #         export CGO_ENABLED=1
-  #         export GOOS=windows
-  #         export GOARCH=amd64
-
-  #         make install-cli
-
-  #         destination="${GITHUB_WORKSPACE}/windows-cli-tools"
-  #         mkdir -p "$destination"
-  #         cp -a "$(go env GOPATH)/bin/$(go env GOOS)_$(go env GOARCH)/." "$destination"
-
-  #     - name: Archive windows-cli-tools
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: windows-cli-tools
-  #         path: windows-cli-tools
-
-  # windows-smoke-tests:
-  #   runs-on: windows-latest
-  #   needs:
-  #     - get-config
-  #     - build-windows-binaries
-  #     - up
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: windows-cli-tools
-  #         path: windows-cli-tools
-
-  #     - name: Log in to Azure
-  #       uses: azure/login@v1
-  #       with:
-  #         client-id: ${{ env.AZURE_CLIENT_ID }}
-  #         tenant-id: ${{ env.AZURE_TENANT_ID }}
-  #         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-  #         enable-AzPSSession: true
-
-  #     - name: Run smoke tests
-  #       env:
-  #         DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
-  #         TYGER_URI: ${{ needs.get-config.outputs.TYGER_URI }}
-  #       shell: pwsh
-  #       run: |
-  #         $ErrorActionPreference = "Stop"
-  #         Set-StrictMode -Version Latest
-
-  #         $env:PATH = "$env:GITHUB_WORKSPACE\windows-cli-tools;" + $env:PATH
-
-  #         $developerConfig = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:DEVELOPER_CONFIG_BASE64)) | ConvertFrom-Json
-
-  #         $servicePrincipal = $developerConfig.testAppUri
-  #         $keyVaultName = $developerConfig.keyVault
-  #         $certificateName = $developerConfig.pkcs12CertSecret.name
-  #         $certificateVersion = $developerConfig.pkcs12CertSecret.version
-
-  #         # Run tests
-  #         .\scripts\Test-CertificateLoginOnWindows.ps1 `
-  #           -ServerUri $env:TYGER_URI `
-  #           -ServicePrincipal $servicePrincipal `
-  #           -KeyVaultName $keyVaultName `
-  #           -CertificateName $certificateName `
-  #           -CertificateVersion $certificateVersion
-
-  # codeql:
-  #   runs-on: ubuntu-latest
-  #   if: github.repository == 'microsoft/tyger'
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   permissions:
-  #     actions: read
-  #     contents: read
-  #     security-events: write
-
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       language: [ 'csharp', 'go' ]
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - uses: actions/setup-go@v4
-  #       if: matrix.language == 'go'
-  #       with:
-  #         go-version-file: cli/go.mod
-  #         cache-dependency-path: cli/go.sum
-
-  #     - uses: actions/setup-dotnet@v3
-  #       with:
-  #         global-json-file: server/global.json
-
-  #     - name: Initialize CodeQL
-  #       uses: github/codeql-action/init@v2
-  #       with:
-  #         languages: ${{ matrix.language }}
-
-  #     - name: "Build"
-  #       run: |
-  #         set -euo pipefail
-  #         make -s build-${{ matrix.language }}
-
-  #     - name: Perform CodeQL Analysis
-  #       uses: github/codeql-action/analyze@v2
-  #       with:
-  #         category: "/language:${{matrix.language}}"
-
-  # publishDocs:
-  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'microsoft/tyger'
-  #   needs:
-  #     - unit-tests-and-format
-  #     - integration-tests
-  #     - get-config
-  #     - windows-smoke-tests
-
-  #   runs-on: ubuntu-latest
-
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-
-  #   # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-  #   permissions:
-  #     contents: read
-  #     pages: write
-  #     id-token: write
-
-  #   # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-  #   # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-  #   concurrency:
-  #     group: "pages"
-  #     cancel-in-progress: false
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Build static page
-  #       run: |
-  #           cd docs
-  #           npm install
-  #           npm run docs:build
-  #     - name: Setup Pages
-  #       uses: actions/configure-pages@v3
-  #     - name: Upload artifact
-  #       uses: actions/upload-pages-artifact@v2
-  #       with:
-  #         # Upload entire repository
-  #         path: 'docs/.vitepress/dist'
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v2
-
-  # release:
-  #   if: startsWith(github.ref, 'refs/tags/')
-  #   needs:
-  #     - unit-tests-and-format
-  #     - integration-tests
-  #     - get-config
-  #     - windows-smoke-tests
-  #   env:
-  #     DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
-  #   permissions:
-  #     contents: write
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - uses: actions/setup-go@v4
-  #       with:
-  #         go-version-file: cli/go.mod
-  #         cache-dependency-path: cli/go.sum
-
-  #     - name: get container registry
-  #       run: |
-  #         set -euo pipefail
-  #         official_container_registry=$(echo "$DEVELOPER_CONFIG_BASE64" | base64 -d | jq -r '.officialContainerRegistry.fqdn')
-  #         echo "OFFICIAL_CONTAINER_REGISTRY=$(echo $official_container_registry)" >> $GITHUB_ENV
-
-  #     - name: Run GoReleaser
-  #       uses: goreleaser/goreleaser-action@v5
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         version: v1.21.2
-  #         workdir: cli
-  #         args: release --clean
+      - name: Log in to Azure
+        uses: ./.github/actions/login-azure
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: up
+        run: |
+          set -euo pipefail
+          make -s up INSTALL_CLOUD=true
+          make -s migrate
+
+  restore-scale-to-zero:
+    needs:
+      - test-azure-needs-hosted-runner
+      - up
+      - get-config
+    runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUNS_ON_JSON)}}
+    defaults:
+      run:
+        shell: bash
+    env:
+      TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Azure
+        uses: ./.github/actions/login-azure
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: restore-scale-to-zero
+        run: |
+          set -euo pipefail
+          make -s ensure-environment
+
+  integration-tests:
+    needs:
+      - test-azure-needs-hosted-runner
+      - get-config
+      - up
+    runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUNS_ON_JSON)}}
+    env:
+      TYGER_MIN_NODE_COUNT: "1"
+      DO_NOT_BUILD_IMAGES: "true"
+      EXPLICIT_IMAGE_TAG: ${{ needs.get-config.outputs.IMAGE_TAG }}
+      TYGER_ENVIRONMENT_NAME: ${{ needs.get-config.outputs.TYGER_ENVIRONMENT_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Azure
+        uses: ./.github/actions/login-azure
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Deploy and test
+        run: |
+          set -euo pipefail
+          make -s integration-test-no-up
+
+  publish-official-images:
+    needs:
+      - test-azure-needs-hosted-runner
+    runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUNS_ON_JSON)}}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Azure
+        uses: ./.github/actions/login-azure
+
+      - name: Publish official images
+        run: |
+          set -euo pipefail
+          make publish-official-images
+
+  build-windows-binaries:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: cli/go.mod
+          # use a different cache key for windows builds
+          cache-dependency-path: |
+            cli/go.sum
+            cli/go.mod
+
+      - name: Build Windows Binaries
+        run: |
+          set -eo pipefail
+
+          export CGO_ENABLED=1
+          export GOOS=windows
+          export GOARCH=amd64
+
+          make install-cli
+
+          destination="${GITHUB_WORKSPACE}/windows-cli-tools"
+          mkdir -p "$destination"
+          cp -a "$(go env GOPATH)/bin/$(go env GOOS)_$(go env GOARCH)/." "$destination"
+
+      - name: Archive windows-cli-tools
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-cli-tools
+          path: windows-cli-tools
+
+  windows-smoke-tests:
+    needs:
+      - test-azure-needs-hosted-runner
+      - get-config
+      - build-windows-binaries
+      - up
+    runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUNS_ON_WINDOWS_JSON)}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-cli-tools
+          path: windows-cli-tools
+
+      - name: Log in to Azure
+        uses: ./.github/actions/login-azure
+
+      - name: Run smoke tests
+        env:
+          DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
+          TYGER_URI: ${{ needs.get-config.outputs.TYGER_URI }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Set-StrictMode -Version Latest
+
+          $env:PATH = "$env:GITHUB_WORKSPACE\windows-cli-tools;" + $env:PATH
+
+          $developerConfig = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:DEVELOPER_CONFIG_BASE64)) | ConvertFrom-Json
+
+          $servicePrincipal = $developerConfig.testAppUri
+          $keyVaultName = $developerConfig.keyVault
+          $certificateName = $developerConfig.pkcs12CertSecret.name
+          $certificateVersion = $developerConfig.pkcs12CertSecret.version
+
+          # Run tests
+          .\scripts\Test-CertificateLoginOnWindows.ps1 `
+            -ServerUri $env:TYGER_URI `
+            -ServicePrincipal $servicePrincipal `
+            -KeyVaultName $keyVaultName `
+            -CertificateName $certificateName `
+            -CertificateVersion $certificateVersion
+
+  codeql:
+    runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/tyger'
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp', 'go' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        if: matrix.language == 'go'
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - uses: actions/setup-dotnet@v3
+        with:
+          global-json-file: server/global.json
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: "Build"
+        run: |
+          set -euo pipefail
+          make -s build-${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"
+
+  publishDocs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'microsoft/tyger'
+    needs:
+      - unit-tests-and-format
+      - integration-tests
+      - get-config
+      - windows-smoke-tests
+
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+    # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build static page
+        run: |
+            cd docs
+            npm install
+            npm run docs:build
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: 'docs/.vitepress/dist'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - unit-tests-and-format
+      - integration-tests
+      - get-config
+      - windows-smoke-tests
+    env:
+      DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: get container registry
+        run: |
+          set -euo pipefail
+          official_container_registry=$(echo "$DEVELOPER_CONFIG_BASE64" | base64 -d | jq -r '.officialContainerRegistry.fqdn')
+          echo "OFFICIAL_CONTAINER_REGISTRY=$(echo $official_container_registry)" >> $GITHUB_ENV
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: v1.21.2
+          workdir: cli
+          args: release --clean

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -32,10 +32,11 @@ jobs:
             AZURE_RUNS_ON_WINDOWS_JSON='"windows-latest"'
           else
             AZURE_RUNS_ON_JSON='["self-hosted", "1ES.Pool=tyger-gh-1es"]'
-
+            AZURE_RUNS_ON_WINDOWS_JSON='["self-hosted", "1ES.Pool=tyger-gh-1es-windows"]'
           fi
 
           echo "AZURE_RUNS_ON_JSON=$AZURE_RUNS_ON_JSON" >> "$GITHUB_OUTPUT"
+          echo "AZURE_RUNS_ON_WINDOWS_JSON=$AZURE_RUNS_ON_WINDOWS_JSON" >> "$GITHUB_OUTPUT"
 
 
   unit-tests-and-format:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -20,12 +20,12 @@ env:
 
 jobs:
 
-  # If this is running a Dependabot PR or PR from a fork, this we won't have access to secrets
-  # nor will be be able to obtaine a federated token to access Azure resources.
+  # If this is running a Dependabot PR or PR from a fork, it we won't have access to secrets
+  # nor will be be able to obtain a federated token to access Azure resources.
   # Therefore, in those cases, we use hosted runners with managed identity to access Azure resources.
-  # Only want to use those when necessary since they are a lot slower to come up, so this job
+  # We only want to use those when necessary since they are a lot slower to come up, so this job
   # determines what we should pass in to `runs-on` for jobs that access Azure resources.
-  # Also, this repo is configured to require approvals for all workflow runs from forks, and we
+  # Also, this repo is configured to require approvals for all workflowd external contributors, and we
   # should inspect the code in the PR before approving the run.
   test-azure-needs-hosted-runner:
     runs-on: ubuntu-latest
@@ -285,8 +285,6 @@ jobs:
 
       - name: Log in to Azure
         uses: ./.github/actions/login-azure
-
-      - run: az account show
 
       - name: Publish official images
         run: |

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -19,6 +19,14 @@ env:
   CAN_ACCESS_SECRETS: ${{ secrets.CAN_ACCESS_SECRETS }}
 
 jobs:
+
+  # If this is running a Dependabot PR or PR from a fork, this we won't have access to secrets
+  # nor will be be able to obtaine a federated token to access Azure resources.
+  # Therefore, in those cases, we use hosted runners with managed identity to access Azure resources.
+  # Only want to use those when necessary since they are a lot slower to come up, so this job
+  # determines what we should pass in to `runs-on` for jobs that access Azure resources.
+  # Also, this repo is configured to require approvals for all workflow runs from forks, and we
+  # should inspect the code in the PR before approving the run.
   test-azure-needs-hosted-runner:
     runs-on: ubuntu-latest
     outputs:
@@ -37,7 +45,6 @@ jobs:
 
           echo "AZURE_RUNS_ON_JSON=$AZURE_RUNS_ON_JSON" >> "$GITHUB_OUTPUT"
           echo "AZURE_RUNS_ON_WINDOWS_JSON=$AZURE_RUNS_ON_WINDOWS_JSON" >> "$GITHUB_OUTPUT"
-
 
   unit-tests-and-format:
     runs-on: ubuntu-latest
@@ -278,6 +285,8 @@ jobs:
 
       - name: Log in to Azure
         uses: ./.github/actions/login-azure
+
+      - run: az account show
 
       - name: Publish official images
         run: |

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - run: |
-          az login --identity --username 789b8572-1fae-4a5f-b376-6d9d14651245 --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --subscription 87d8acb3-5176-4651-b457-6ab9cefd8e3d
+          az login --identity --username 789b8572-1fae-4a5f-b376-6d9d14651245 --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47
           az account show
 
   # unit-tests-and-format:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - run: |
-          az login --identity --username 789b8572-1fae-4a5f-b376-6d9d14651245 --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47
+          az login --identity --username 789b8572-1fae-4a5f-b376-6d9d14651245
           az account show
 
   # unit-tests-and-format:

--- a/cli/integrationtest/migrations_test.go
+++ b/cli/integrationtest/migrations_test.go
@@ -46,7 +46,7 @@ func TestMigrations(t *testing.T) {
 	ctx := context.Background()
 
 	ctx = install.SetConfigOnContext(ctx, &config)
-	cred, err := azidentity.NewAzureCLICredential(
+	cred, err := install.NewMiAwareAzureCLICredential(
 		&azidentity.AzureCLICredentialOptions{
 			TenantID: config.Cloud.TenantID,
 		})

--- a/cli/internal/cmd/install/identities.go
+++ b/cli/internal/cmd/install/identities.go
@@ -41,7 +41,7 @@ func newIdentitiesInstallCommand() *cobra.Command {
 			ctx := commonPrerun(cmd.Context(), &flags)
 
 			config := install.GetConfigFromContext(ctx)
-			cred, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{TenantID: config.Api.Auth.TenantID})
+			cred, err := install.NewMiAwareAzureCLICredential(&azidentity.AzureCLICredentialOptions{TenantID: config.Api.Auth.TenantID})
 			if err != nil {
 				return err
 			}

--- a/cli/internal/cmd/install/installcommon.go
+++ b/cli/internal/cmd/install/installcommon.go
@@ -94,7 +94,7 @@ func getDefaultConfigPath() string {
 
 func loginAndValidateSubscription(ctx context.Context) (context.Context, error) {
 	config := install.GetConfigFromContext(ctx)
-	cred, err := azidentity.NewAzureCLICredential(
+	cred, err := install.NewMiAwareAzureCLICredential(
 		&azidentity.AzureCLICredentialOptions{
 			TenantID: config.Cloud.TenantID,
 		})

--- a/cli/internal/install/cred.go
+++ b/cli/internal/install/cred.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package install
 
 import (

--- a/cli/internal/install/cred.go
+++ b/cli/internal/install/cred.go
@@ -1,0 +1,81 @@
+package install
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+)
+
+var (
+	ErrNotLoggedIn = errors.New("You must run `az login` before running this command")
+)
+
+// az account get-access-token fails if --tenant is provided and the user is logged in with a managed identity
+// This creates a TokenProvider that works around this case
+func NewMiAwareAzureCLICredential(options *azidentity.AzureCLICredentialOptions) (azcore.TokenCredential, error) {
+	cmd := exec.Command("az", "account", "show")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil, ErrNotLoggedIn
+	}
+
+	outputMap := make(map[string]any)
+	if err := json.Unmarshal(out.Bytes(), &outputMap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal az account show output: %w", err)
+	}
+
+	userMap := outputMap["user"].(map[string]any)
+	if userMap["type"] == "servicePrincipal" {
+		if name := userMap["name"].(string); name == "systemAssignedIdentity" || name == "userAssignedIdentity" {
+			currentTenantId := outputMap["tenantId"].(string)
+
+			if options != nil {
+				if options.TenantID != "" && options.TenantID != currentTenantId || len(options.AdditionallyAllowedTenants) > 0 {
+					return nil, fmt.Errorf("the managed identity account only supports tenant %s", currentTenantId)
+				}
+
+				options.TenantID = ""
+			}
+
+			innerCred, err := azidentity.NewAzureCLICredential(options)
+			if err != nil {
+				return nil, err
+			}
+
+			return &miAwareAzureCLICredential{
+				cred:     innerCred,
+				tenantID: currentTenantId,
+			}, nil
+		}
+	}
+
+	// return a regular AzureCLICredential
+	return azidentity.NewAzureCLICredential(options)
+}
+
+type miAwareAzureCLICredential struct {
+	cred     *azidentity.AzureCLICredential
+	tenantID string
+}
+
+func (cred *miAwareAzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	if opts.TenantID != "" {
+		if opts.TenantID != cred.tenantID {
+			return azcore.AccessToken{}, fmt.Errorf("the managed identity account only supports tenant %s", cred.tenantID)
+		}
+
+		newOps := opts
+		newOps.TenantID = ""
+
+		return cred.cred.GetToken(ctx, newOps)
+	}
+	return cred.cred.GetToken(ctx, opts)
+}

--- a/deploy/config/microsoft/config.yml
+++ b/deploy/config/microsoft/config.yml
@@ -24,7 +24,7 @@ cloud:
             maxCount: 10
 
     managementPrincipals:
-      - id: 2e3f2a18-8bbf-44c7-8164-8019843c68fc
+      - id: 2e092785-472a-4ea1-9700-4d15646d9e91
         kind: ServicePrincipal
       - id: c0e60aba-35f0-4778-bc9b-fc5d2af14687
         kind: Group


### PR DESCRIPTION
Dependabot PRs and PRs from forks do not have access to secrets nor do they have the ability to get a federated credential. (Meaning #89 did not actually help us).

Instead, we will run on hosted runners configured with managed identity in those cases. Workflows on forks need explicit approval before they start.

Also, `tyger install` did not work properly when `az` was logged in with a managed identity.