### PR TITLE
Fix constants in Goreleaser config

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -11,8 +11,8 @@ builds:
     ldflags:
       - -s -w
       - -X main.version={{ .Tag }}
-      - -X github.com/microsoft/tyger/cli/internal/install.containerRegistry={{ .Env.OFFICIAL_CONTAINER_REGISTRY }}
-      - -X github.com/microsoft/tyger/cli/internal/install.containerImageTag={{ .Tag }}
+      - -X github.com/microsoft/tyger/cli/internal/install.ContainerRegistry={{ .Env.OFFICIAL_CONTAINER_REGISTRY }}
+      - -X github.com/microsoft/tyger/cli/internal/install.ContainerImageTag={{ .Tag }}
     goos:
       - linux
       - windows


### PR DESCRIPTION
Fixing an issue reported by @yuliadub where the v0.5.0 release is broken because I did not update constants in the Goreleaser config file.