### PR TITLE
Support least privilege IDs during `tyger api install`

### DIFF
--- a/.github/actions/login-azure/action.yml
+++ b/.github/actions/login-azure/action.yml
@@ -16,7 +16,7 @@ runs:
         sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
         sudo mkdir -p /etc/apt/keyrings
         curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
-            sudo gpg --no-tty --dearmor -o /etc/apt/keyrings/microsoft.gpg
+            sudo gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/microsoft.gpg
         sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
         AZ_DIST=$(lsb_release -cs)
         echo "Types: deb

--- a/.github/actions/login-azure/action.yml
+++ b/.github/actions/login-azure/action.yml
@@ -16,7 +16,7 @@ runs:
         sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
         sudo mkdir -p /etc/apt/keyrings
         curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
-            sudo gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/microsoft.gpg
+            sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/microsoft.gpg
         sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
         AZ_DIST=$(lsb_release -cs)
         echo "Types: deb

--- a/.github/actions/login-azure/action.yml
+++ b/.github/actions/login-azure/action.yml
@@ -16,7 +16,7 @@ runs:
         sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
         sudo mkdir -p /etc/apt/keyrings
         curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
-            sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+            sudo gpg --no-tty --dearmor -o /etc/apt/keyrings/microsoft.gpg
         sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
         AZ_DIST=$(lsb_release -cs)
         echo "Types: deb

--- a/cli/internal/install/cloudinstall/azurerbac.go
+++ b/cli/internal/install/cloudinstall/azurerbac.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const rbacAssignmentCreatedByTyger = "Assigned by Tyger"
+
 func getRbacRole(ctx context.Context, credential azcore.TokenCredential, scope string, roleName string) (string, error) {
 	roleDefClient, err := armauthorization.NewRoleDefinitionsClient(credential, nil)
 	if err != nil {
@@ -44,7 +46,10 @@ func getRbacRole(ctx context.Context, credential azcore.TokenCredential, scope s
 	return roleId, nil
 }
 
-func assignRbacRole(ctx context.Context, principalId, scope, roleName, subscriptionId string, credential azcore.TokenCredential) error {
+// Assign the specified role to principalIds at the specified scope.
+// Existing assignments to the same role to different principals will be removed
+// if they were created by this tool and deleteOtherAssignments is true.
+func assignRbacRole(ctx context.Context, principalIds []string, deleteOtherAssignments bool, scope, roleName, subscriptionId string, credential azcore.TokenCredential) error {
 	roleId, err := getRbacRole(ctx, credential, scope, roleName)
 	if err != nil {
 		return fmt.Errorf("failed to get %s role: %w", roleName, err)
@@ -55,6 +60,13 @@ func assignRbacRole(ctx context.Context, principalId, scope, roleName, subscript
 		return fmt.Errorf("failed to create role assignments client: %w", err)
 	}
 
+	principalIdsToAdd := make(map[string]any)
+	for _, principalId := range principalIds {
+		principalIdsToAdd[principalId] = nil
+	}
+
+	roleAssignmentsToDelete := make([]*armauthorization.RoleAssignment, 0)
+
 	pager := roleAssignmentClient.NewListForScopePager(scope, nil)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
@@ -63,41 +75,62 @@ func assignRbacRole(ctx context.Context, principalId, scope, roleName, subscript
 		}
 
 		for _, ra := range page.RoleAssignmentListResult.Value {
-			if *ra.Properties.RoleDefinitionID == roleId && *ra.Properties.PrincipalID == principalId {
-				return nil
-			}
-		}
-	}
-
-	for i := 0; ; i++ {
-		_, err = roleAssignmentClient.Create(
-			ctx,
-			scope,
-			uuid.New().String(),
-			armauthorization.RoleAssignmentCreateParameters{
-				Properties: &armauthorization.RoleAssignmentProperties{
-					RoleDefinitionID: Ptr(roleId),
-					PrincipalID:      Ptr(principalId),
-				},
-			}, nil)
-		if err != nil {
-			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) {
-				switch respErr.ErrorCode {
-				case "RoleAssignmentExists":
-					return nil
-				case "PrincipalNotFound":
-					if i > 60 {
-						break
-					}
-					time.Sleep(10 * time.Second)
-					continue
+			if *ra.Properties.RoleDefinitionID == roleId {
+				if _, ok := principalIdsToAdd[*ra.Properties.PrincipalID]; ok {
+					delete(principalIdsToAdd, *ra.Properties.PrincipalID)
+				} else if ra.Properties.Description != nil && *ra.Properties.Description == rbacAssignmentCreatedByTyger {
+					roleAssignmentsToDelete = append(roleAssignmentsToDelete, ra)
 				}
 			}
 		}
-
-		return err
 	}
+
+	for principalId := range principalIdsToAdd {
+		completed := false
+		for i := 0; !completed; i++ {
+			_, err = roleAssignmentClient.Create(
+				ctx,
+				scope,
+				uuid.New().String(),
+				armauthorization.RoleAssignmentCreateParameters{
+					Properties: &armauthorization.RoleAssignmentProperties{
+						RoleDefinitionID: Ptr(roleId),
+						PrincipalID:      Ptr(principalId),
+						Description:      Ptr(rbacAssignmentCreatedByTyger),
+					},
+				}, nil)
+			if err != nil {
+				var respErr *azcore.ResponseError
+				if errors.As(err, &respErr) {
+					switch respErr.ErrorCode {
+					case "RoleAssignmentExists":
+						completed = true
+					case "PrincipalNotFound":
+						if i > 60 {
+							return err
+						}
+						time.Sleep(10 * time.Second)
+						continue
+					default:
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	if !deleteOtherAssignments {
+		return nil
+	}
+
+	for _, ra := range roleAssignmentsToDelete {
+		_, err = roleAssignmentClient.DeleteByID(ctx, *ra.ID, nil)
+		if err != nil {
+			return fmt.Errorf("failed to delete role assignment: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func removeRbacRoleAssignments(ctx context.Context, principalId, scope, subscriptionId string, credential azcore.TokenCredential) error {

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -37,8 +37,17 @@ type CloudConfig struct {
 
 type ComputeConfig struct {
 	Clusters                   []*ClusterConfig `json:"clusters"`
-	ManagementPrincipals       []AksPrincipal   `json:"managementPrincipals"`
+	ManagementPrincipals       []Principal      `json:"managementPrincipals"`
+	LocalDevelopmentIdentityId string           `json:"localDevelopmentIdentityId"` // undocumented - for local development only
 	PrivateContainerRegistries []string         `json:"privateContainerRegistries"`
+}
+
+func (c *ComputeConfig) GetManagementPrincipalIds() []string {
+	var ids []string
+	for _, p := range c.ManagementPrincipals {
+		ids = append(ids, p.ObjectId)
+	}
+	return ids
 }
 
 type NamedAzureResource struct {
@@ -55,13 +64,12 @@ const (
 )
 
 type Principal struct {
-	ObjectId string        `json:"objectId"`
-	Kind     PrincipalKind `json:"kind"`
-}
+	ObjectId          string        `json:"objectId"`
+	UserPrincipalName string        `json:"userPrincipalName"`
+	Kind              PrincipalKind `json:"kind"`
 
-type AksPrincipal struct {
-	Kind PrincipalKind `json:"kind"`
-	Id   string        `json:"id"`
+	// Deprecated: Id is deprecated. Use ObjectId instead
+	Id string `json:"id"`
 }
 
 func (c *ComputeConfig) GetApiHostCluster() *ClusterConfig {
@@ -75,12 +83,11 @@ func (c *ComputeConfig) GetApiHostCluster() *ClusterConfig {
 }
 
 type ClusterConfig struct {
-	Name                       string            `json:"name"`
-	ApiHost                    bool              `json:"apiHost"`
-	Location                   string            `json:"location"`
-	KubernetesVersion          string            `json:"kubernetesVersion,omitempty"`
-	UserNodePools              []*NodePoolConfig `json:"userNodePools"`
-	LocalDevelopmentIdentityId string            `json:"localDevelopmentIdentityId"` // undocumented - for local development only
+	Name              string            `json:"name"`
+	ApiHost           bool              `json:"apiHost"`
+	Location          string            `json:"location"`
+	KubernetesVersion string            `json:"kubernetesVersion,omitempty"`
+	UserNodePools     []*NodePoolConfig `json:"userNodePools"`
 }
 
 type NodePoolConfig struct {
@@ -155,9 +162,7 @@ type ConfigTemplateValues struct {
 	SubscriptionId           string
 	DefaultLocation          string
 	KubernetesVersion        string
-	PrincipalId              string
-	PrincipalDisplay         string
-	PrincipalKind            PrincipalKind
+	Principal                Principal
 	DatabaseServerName       string
 	PostgresMajorVersion     int
 	BufferStorageAccountName string

--- a/cli/internal/install/cloudinstall/config.tpl
+++ b/cli/internal/install/cloudinstall/config.tpl
@@ -29,19 +29,25 @@ cloud:
             minCount: {{ .GpuNodePoolMinCount }}
             maxCount: 10
 
-    # These are the principals that will be granted full access to the
-    # "tyger" namespace in each cluster.
-    # For users, kind must be "User".
-    #   If the user's home tenant is this subscription's tenant and
-    #   is not a personal Microsoft account, set id to the user
-    #   principal name (email). Otherwise, set id to the object ID (GUID).
-    # For service principals, kind must also be "User" and id must
-    # be the service principal's object ID (GUID).
-    # For groups, kind must be "Group" and id must be the group's
-    # object ID (GUID).
+    # These are the principals that will have the ability to run `tyger api install`.
+    # They will have access to the "tyger" namespace in each cluster and will have
+    # the necessary Azure RBAC role assignments.
+    # For users:
+    #   "kind" must be set to "User"
+    #   "objectId" must be set to the object ID GUID
+    #   "userPrincipalName" must be set (this is usually the email address, unless this is a guest account)
+    # For groups:
+    #   "kind" must be set to "Group"
+    #   "objectId" must be set to the object ID GUID
+    # For service principals:
+    #   "kind" must be set to "ServicePrincipal"
+    #   "objectId" must be set to the object ID GUID
     managementPrincipals:
-      - kind: {{ .PrincipalKind }}
-        id: {{ .PrincipalId }} {{- if not (contains .PrincipalId "@") }} # {{ .PrincipalDisplay }} {{- end }}
+      - kind: {{ .Principal.Kind }}
+        {{- if .Principal.UserPrincipalName }}
+        userPrincipalName: {{ .Principal.UserPrincipalName }}
+        {{- end }}
+        objectId: {{ .Principal.ObjectId }}
 
     # The names of private container registries that the clusters must
     # be able to pull from.

--- a/cli/internal/install/cloudinstall/config_test.go
+++ b/cli/internal/install/cloudinstall/config_test.go
@@ -14,13 +14,16 @@ import (
 
 func TestRenderConfig(t *testing.T) {
 	values := ConfigTemplateValues{
-		EnvironmentName:          "abc",
-		ResourceGroup:            "def",
-		TenantId:                 "tenant",
-		SubscriptionId:           "sub",
-		DefaultLocation:          "westus",
-		PrincipalId:              uuid.New().String(),
-		PrincipalKind:            PrincipalKindUser,
+		EnvironmentName: "abc",
+		ResourceGroup:   "def",
+		TenantId:        "tenant",
+		SubscriptionId:  "sub",
+		DefaultLocation: "westus",
+		Principal: Principal{
+			ObjectId:          uuid.New().String(),
+			Kind:              PrincipalKindUser,
+			UserPrincipalName: "my@example.com",
+		},
 		BufferStorageAccountName: "acc1",
 		LogsStorageAccountName:   "acc2",
 		DomainName:               "dom.ain",
@@ -39,18 +42,11 @@ func TestRenderConfig(t *testing.T) {
 	require.Equal(t, values.TenantId, config.Cloud.TenantID)
 	require.Equal(t, values.SubscriptionId, config.Cloud.SubscriptionID)
 	require.Equal(t, values.DefaultLocation, config.Cloud.DefaultLocation)
-	require.Equal(t, values.PrincipalKind, config.Cloud.Compute.ManagementPrincipals[0].Kind)
+	require.Equal(t, values.Principal.Kind, config.Cloud.Compute.ManagementPrincipals[0].Kind)
+	require.Equal(t, values.Principal.ObjectId, config.Cloud.Compute.ManagementPrincipals[0].ObjectId)
+	require.Equal(t, values.Principal.UserPrincipalName, config.Cloud.Compute.ManagementPrincipals[0].UserPrincipalName)
 	require.Equal(t, values.BufferStorageAccountName, config.Cloud.Storage.Buffers[0].Name)
 	require.Equal(t, values.LogsStorageAccountName, config.Cloud.Storage.Logs.Name)
 	require.Equal(t, values.DomainName, config.Api.DomainName)
 	require.Equal(t, values.ApiTenantId, config.Api.Auth.TenantID)
-
-	values.PrincipalKind = PrincipalKindServicePrincipal
-
-	buf.Reset()
-	require.NoError(t, RenderConfig(values, &buf))
-	config = CloudEnvironmentConfig{}
-	require.NoError(t, yaml.UnmarshalStrict(buf.Bytes(), &config))
-
-	require.Equal(t, values.PrincipalId, config.Cloud.Compute.ManagementPrincipals[0].Id)
 }

--- a/cli/internal/install/cloudinstall/helm.go
+++ b/cli/internal/install/cloudinstall/helm.go
@@ -375,7 +375,7 @@ func (inst *Installer) InstallTygerHelmChart(ctx context.Context, restConfig *re
 		return "", "", fmt.Errorf("failed to create PostgreSQL server client: %w", err)
 	}
 
-	dbServerName, err := inst.getDatabaseServerName(ctx, false)
+	dbServerName, err := inst.getDatabaseServerName(ctx, &tygerServerIdentity.Identity, false)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get database server name: %w", err)
 	}

--- a/cli/internal/install/cloudinstall/mi.go
+++ b/cli/internal/install/cloudinstall/mi.go
@@ -48,6 +48,10 @@ func (inst *Installer) createManagedIdentity(ctx context.Context, name string) (
 		return nil, fmt.Errorf("failed to create managed identity: %w", err)
 	}
 
+	if err := assignRbacRole(ctx, inst.Config.Cloud.Compute.GetManagementPrincipalIds(), true, *resp.ID, "Reader", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
+		return nil, fmt.Errorf("failed to assign RBAC role on managed identity: %w", err)
+	}
+
 	return &resp.Identity, nil
 }
 

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -13,7 +13,6 @@ cloud:
       - name: ${TYGER_ENVIRONMENT_NAME}
         apiHost: true
         kubernetesVersion: 1.27
-        localDevelopmentIdentityId: c0e60aba-35f0-4778-bc9b-fc5d2af14687
         userNodePools:
           - name: cpunp
             vmSize: Standard_DS12_v2
@@ -25,11 +24,12 @@ cloud:
             maxCount: 10
 
     managementPrincipals:
-      - id: 2e092785-472a-4ea1-9700-4d15646d9e91
+      - objectId: 2e092785-472a-4ea1-9700-4d15646d9e91
         kind: ServicePrincipal
-      - id: c0e60aba-35f0-4778-bc9b-fc5d2af14687
+      - objectId: 36043a62-1383-4012-95aa-44da0a4d8012
         kind: Group
 
+    localDevelopmentIdentityId: 36043a62-1383-4012-95aa-44da0a4d8012
     privateContainerRegistries:
       - eminence
 

--- a/docs/introduction/installation/cloud-installation.md
+++ b/docs/introduction/installation/cloud-installation.md
@@ -84,19 +84,23 @@ cloud:
             minCount: 0
             maxCount: 10
 
-    # These are the principals that will be granted full access to the
-    # "tyger" namespace in each cluster.
-    # For users, kind must be "User".
-    #   If the user's home tenant is this subscription's tenant and
-    #   is not a personal Microsoft account, set id to the user
-    #   principal name (email). Otherwise, set id to the object ID (GUID).
-    # For service principals, kind must also be "User" and id must
-    # be the service principal's object ID (GUID).
-    # For groups, kind must be "Group" and id must be the group's
-    # object ID (GUID).
+    # These are the principals that will have the ability to run `tyger api install`.
+    # They will have access to the "tyger" namespace in each cluster and will have
+    # the necessary Azure RBAC role assignments.
+    # For users:
+    #   "kind" must be set to "User"
+    #   "objectId" must be set to the object ID GUID
+    #   "userPrincipalName" must be set (this is usually the email address, unless this is a guest account)
+    # For groups:
+    #   "kind" must be set to "Group"
+    #   "objectId" must be set to the object ID GUID
+    # For service principals:
+    #   "kind" must be set to "ServicePrincipal"
+    #   "objectId" must be set to the object ID GUID
     managementPrincipals:
       - kind: User
-        id: me@example.com
+        userPrincipalName: me@example.com
+        objectId: 18c9e451-88aa-47d2-ae4f-1d34d55dc50c
 
     # The names of private container registries that the clusters must
     # be able to pull from.


### PR DESCRIPTION
- Changing logic in `tyger cloud install` such that `tyger api install` can be done with principals that do not have any persistent access to either the subscription or resource groups.
- Disabling shared key access on storage accounts