### PR TITLE
Reduce storage account permissions

### DIFF
--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -38,7 +38,6 @@ type CloudConfig struct {
 type ComputeConfig struct {
 	Clusters                   []*ClusterConfig `json:"clusters"`
 	ManagementPrincipals       []Principal      `json:"managementPrincipals"`
-	LocalDevelopmentIdentityId string           `json:"localDevelopmentIdentityId"` // undocumented - for local development only
 	PrivateContainerRegistries []string         `json:"privateContainerRegistries"`
 }
 

--- a/cli/internal/install/cloudinstall/storage.go
+++ b/cli/internal/install/cloudinstall/storage.go
@@ -74,15 +74,7 @@ func (inst *Installer) CreateStorageAccount(ctx context.Context,
 		return nil, fmt.Errorf("failed to assign storage RBAC role: %w", err)
 	}
 
-	dataContributorPrincipals := []string{*managedIdentity.Properties.PrincipalID}
-	for _, p := range inst.Config.Cloud.Compute.ManagementPrincipals {
-		dataContributorPrincipals = append(dataContributorPrincipals, p.ObjectId)
-	}
-	if localId := inst.Config.Cloud.Compute.LocalDevelopmentIdentityId; localId != "" {
-		dataContributorPrincipals = append(dataContributorPrincipals, localId)
-	}
-
-	if err := assignRbacRole(ctx, dataContributorPrincipals, true, *res.ID, "Storage Blob Data Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
+	if err := assignRbacRole(ctx, []string{*managedIdentity.Properties.PrincipalID}, true, *res.ID, "Storage Blob Data Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
 		return nil, fmt.Errorf("failed to assign storage RBAC role: %w", err)
 	}
 

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -29,7 +29,6 @@ cloud:
       - objectId: 36043a62-1383-4012-95aa-44da0a4d8012
         kind: Group
 
-    localDevelopmentIdentityId: 36043a62-1383-4012-95aa-44da0a4d8012
     privateContainerRegistries:
       - eminence
 


### PR DESCRIPTION
Removing unnecessary permissions on the storage accounts we deploy. 