### PR TITLE
Change buffer search tag query parameter format

### DIFF
--- a/Makefile.cloud
+++ b/Makefile.cloud
@@ -142,6 +142,18 @@ login: install-cli download-test-client-cert
 	EOF
 	)
 
+login-local: install-cli download-test-client-cert
+	cert_version=$$(echo '${DEVELOPER_CONFIG_JSON}' | jq -r '.pemCertSecret.version')
+	cert_path=$${HOME}/tyger_test_client_cert_$${cert_version}.pem
+	test_app_uri=$$(echo '${DEVELOPER_CONFIG_JSON}' | jq -r '.testAppUri')
+
+	tyger login -f <(cat <<EOF
+	serverUri: http://localhost:5000
+	servicePrincipal: $${test_app_uri}
+	certificatePath: $${cert_path}
+	EOF
+	)
+
 start-proxy: install-cli download-test-client-cert
 	cert_version=$$(echo '${DEVELOPER_CONFIG_JSON}' | jq -r '.pemCertSecret.version')
 	cert_path=$${HOME}/tyger_test_client_cert_$${cert_version}.pem

--- a/cli/integrationtest/expected_openapi_spec.yaml
+++ b/cli/integrationtest/expected_openapi_spec.yaml
@@ -35,6 +35,14 @@ paths:
           in: query
           schema:
             type: string
+        - name: tag
+          in: query
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
       responses:
         '200':
           description: Success

--- a/cli/internal/cmd/buffer.go
+++ b/cli/internal/cmd/buffer.go
@@ -424,7 +424,7 @@ func newBufferListCommand() *cobra.Command {
 			}
 
 			for name, value := range tagEntries {
-				listOptions.Add(fmt.Sprintf("tag.%s", name), value)
+				listOptions.Add(fmt.Sprintf("tag[%s]", name), value)
 			}
 
 			relativeUri := fmt.Sprintf("v1/buffers?%s", listOptions.Encode())

--- a/server/ControlPlane/Buffers/Buffers.cs
+++ b/server/ControlPlane/Buffers/Buffers.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
+using Microsoft.OpenApi.Models;
 using Tyger.Common.Api;
 using Tyger.ControlPlane.Json;
 using Tyger.ControlPlane.Model;
@@ -65,9 +66,9 @@ public static class Buffers
 
                 foreach (var tag in context.Request.Query)
                 {
-                    if (tag.Key.StartsWith("tag.", StringComparison.Ordinal))
+                    if (tag.Key.StartsWith("tag[", StringComparison.Ordinal) && tag.Key.EndsWith(']') && tag.Value.Count > 0)
                     {
-                        tagQuery.Add(tag.Key[4..], tag.Value.FirstOrDefault() ?? "");
+                        tagQuery.Add(tag.Key[4..^1], tag.Value.FirstOrDefault() ?? "");
                     }
                 }
 
@@ -97,7 +98,33 @@ public static class Buffers
                 return Results.Ok(new BufferPage(buffers.AsReadOnly(), nextLink == null ? null : new Uri(nextLink)));
             })
             .WithName("getBuffers")
-            .Produces<BufferPage>();
+            .Produces<BufferPage>()
+            .WithOpenApi(c =>
+                {
+                    // Specify that the query parameter "tag" is a "deep object"
+                    // and can be used like this `tag[key1]=value1&tag[key2]=value2`.
+                    c.Parameters.Add(new OpenApiParameter
+                    {
+                        Name = "tag",
+                        In = ParameterLocation.Query,
+                        Required = false,
+                        Schema = new OpenApiSchema
+                        {
+                            Type = "object",
+                            AdditionalProperties = new OpenApiSchema
+                            {
+                                Type = "string",
+                            },
+                        },
+                        Style = ParameterStyle.DeepObject,
+                        Explode = true,
+                    });
+
+                    // For some reason the text is changed to "OK" when we implement this,
+                    // so we need to set it back to "Success".
+                    c.Responses["200"].Description = "Success";
+                    return c;
+                });
 
         app.MapGet("/v1/buffers/{id}", async (BufferManager manager, HttpContext context, string id, CancellationToken cancellationToken) =>
             {

--- a/server/ControlPlane/OpenApi/OpenApi.cs
+++ b/server/ControlPlane/OpenApi/OpenApi.cs
@@ -61,7 +61,6 @@ public static class OpenApi
 
             });
             c.SchemaFilter<ModelBaseSchemaFilter>();
-            c.OperationFilter<ParameterStyleWorkaroundFilter>();
 
             var filePath = Path.Combine(AppContext.BaseDirectory, "tyger-server.xml");
             c.IncludeXmlComments(filePath);
@@ -85,21 +84,6 @@ internal sealed class ModelBaseSchemaFilter : ISchemaFilter
             // properties because of the [JsonExtensionData] member. But that is only
             // there to fail when unrecognized fields are encountered during deserialization.
             schema.AdditionalPropertiesAllowed = false;
-        }
-    }
-}
-
-// Workaround for https://github.com/microsoft/OpenAPI.NET/issues/1132
-internal sealed class ParameterStyleWorkaroundFilter : IOperationFilter
-{
-    public void Apply(OpenApiOperation operation, OperationFilterContext context)
-    {
-        if (operation.Parameters != null)
-        {
-            foreach (var parameter in operation.Parameters)
-            {
-                parameter.Style = null;
-            }
         }
     }
 }


### PR DESCRIPTION
Update the way tags are specified as search criteria when listing buffers from `tag.key=value` to `tag[key]=value` to make them part of the OpenAPI spec.