### PR TITLE
Change behavior of `tyger buffer set`

### DIFF
--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -1359,14 +1359,47 @@ func TestBufferSetTags(t *testing.T) {
 	bufferId := runTygerSucceeds(t, "buffer", "create", "--tag", "testtag1=testvalue1", "--tag", "testtag2=testvalue2")
 	t.Logf("Buffer ID: %s", bufferId)
 
-	bufferJson := runTygerSucceeds(t, "buffer", "set", bufferId, "--tag", "testtag3=testvalue3", "--tag", "testtag4=testvalue4")
+	bufferJson := runTygerSucceeds(t, "buffer", "set", bufferId, "--tag", "testtag2=testvalue2updated", "--tag", "testtag3=testvalue3")
 
 	var buffer model.Buffer
 	require.NoError(json.Unmarshal([]byte(bufferJson), &buffer))
 
-	require.Equal(2, len(buffer.Tags))
-	require.Equal("testvalue3", buffer.Tags["testtag3"])
-	require.Equal("testvalue4", buffer.Tags["testtag4"])
+	require.Equal(map[string]string{"testtag1": "testvalue1", "testtag2": "testvalue2updated", "testtag3": "testvalue3"}, buffer.Tags)
+}
+
+func TestBufferSetTagsWithClear(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	bufferId := runTygerSucceeds(t, "buffer", "create", "--tag", "testtag1=testvalue1", "--tag", "testtag2=testvalue2")
+	t.Logf("Buffer ID: %s", bufferId)
+
+	bufferJson := runTygerSucceeds(t, "buffer", "set", bufferId, "--clear-tags", "--tag", "testtag3=testvalue3", "--tag", "testtag4=testvalue4")
+
+	var buffer model.Buffer
+	require.NoError(json.Unmarshal([]byte(bufferJson), &buffer))
+
+	require.Equal(map[string]string{"testtag3": "testvalue3", "testtag4": "testvalue4"}, buffer.Tags)
+}
+
+func TestBufferSetTagsClearWithETag(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	bufferJson := runTygerSucceeds(t, "buffer", "create", "--tag", "testtag1=testvalue1", "--tag", "testtag2=testvalue2", "--full-resource")
+
+	var bufferETag model.Buffer
+	require.NoError(json.Unmarshal([]byte(bufferJson), &bufferETag))
+
+	t.Logf("Buffer ID: %s eTag: %s", bufferETag.Id, bufferETag.ETag)
+
+	bufferJson = runTygerSucceeds(t, "buffer", "set", bufferETag.Id, "--clear-tags", "--tag", "testtag3=testvalue3", "--tag", "testtag4=testvalue4", "--etag", bufferETag.ETag)
+
+	var buffer model.Buffer
+	require.NoError(json.Unmarshal([]byte(bufferJson), &buffer))
+
+	require.Equal(map[string]string{"testtag3": "testvalue3", "testtag4": "testvalue4"}, buffer.Tags)
+	require.NotEqual(bufferETag.ETag, buffer.ETag)
 }
 
 func TestBufferSetTagsWithETag(t *testing.T) {
@@ -1380,14 +1413,12 @@ func TestBufferSetTagsWithETag(t *testing.T) {
 
 	t.Logf("Buffer ID: %s eTag: %s", bufferETag.Id, bufferETag.ETag)
 
-	bufferJson = runTygerSucceeds(t, "buffer", "set", bufferETag.Id, "--tag", "testtag3=testvalue3", "--tag", "testtag4=testvalue4", "--etag", bufferETag.ETag)
+	bufferJson = runTygerSucceeds(t, "buffer", "set", bufferETag.Id, "--tag", "testtag2=testvalue2updated", "--tag", "testtag4=testvalue4", "--etag", bufferETag.ETag)
 
 	var buffer model.Buffer
 	require.NoError(json.Unmarshal([]byte(bufferJson), &buffer))
 
-	require.Equal(2, len(buffer.Tags))
-	require.Equal("testvalue3", buffer.Tags["testtag3"])
-	require.Equal("testvalue4", buffer.Tags["testtag4"])
+	require.Equal(map[string]string{"testtag1": "testvalue1", "testtag2": "testvalue2updated", "testtag4": "testvalue4"}, buffer.Tags)
 	require.NotEqual(bufferETag.ETag, buffer.ETag)
 }
 
@@ -1401,7 +1432,7 @@ func TestBufferSetWithInvalidETag(t *testing.T) {
 	runTygerSucceeds(t, "buffer", "show", bufferId)
 
 	_, stderr, _ := runTyger("buffer", "set", bufferId, "--etag", "bad-etag")
-	require.Contains(stderr, "412 Precondition Failed")
+	require.Contains(stderr, "the server's ETag does not match the provided ETag")
 
 	_, stderr2, _ := runTyger("buffer", "set", "bad-bufferid", "--etag", "bad-etag")
 	require.Contains(stderr2, "404 Not Found")
@@ -1414,7 +1445,7 @@ func TestBufferSetClearTags(t *testing.T) {
 	bufferId := runTygerSucceeds(t, "buffer", "create", "--tag", "testtag1=testvalue1", "--tag", "testtag2=testvalue2")
 	t.Logf("Buffer ID: %s", bufferId)
 
-	bufferJson := runTygerSucceeds(t, "buffer", "set", bufferId)
+	bufferJson := runTygerSucceeds(t, "buffer", "set", bufferId, "--clear-tags")
 
 	var buffer model.Buffer
 	require.NoError(json.Unmarshal([]byte(bufferJson), &buffer))

--- a/cli/internal/cmd/buffer.go
+++ b/cli/internal/cmd/buffer.go
@@ -100,35 +100,76 @@ func (t Tags) MarshalJSON() ([]byte, error) {
 func newBufferSetCommand() *cobra.Command {
 	var etag string
 	tagEntries := make(map[string]string)
+	clearTags := false
 	cmd := &cobra.Command{
-		Use:                   "set ID [--etag ETAG] [--tag key=value ...]",
-		Short:                 "Sets replaces the tags set on a buffer",
-		Long:                  `Sets replaces the tags set on a buffer`,
+		Use:                   "set ID [--clear-tags] [--tag key=value ...] [--etag ETAG]",
+		Short:                 "Updates or replaces tags set on a buffer",
+		Long:                  "Updates or replaces tags set on a buffer",
 		Args:                  exactlyOneArg("buffer ID"),
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			buffer := model.Buffer{}
-			var headers = make(http.Header)
-			if etag != "" {
-				headers.Add("If-Match", etag)
-			}
+			for {
 
-			_, err := controlplane.InvokeRequest(cmd.Context(), http.MethodPut, fmt.Sprintf("v1/buffers/%s/tags", args[0]), Tags(tagEntries), &buffer, controlplane.WithHeaders(headers))
-			if err != nil {
-				return err
-			}
+				buffer := model.Buffer{}
+				var headers = make(http.Header)
+				requestEtag := etag
 
-			formattedBuffer, err := json.MarshalIndent(buffer, "", "  ")
-			if err != nil {
-				return err
-			}
+				var newTagEntries map[string]string
+				if clearTags {
+					newTagEntries = tagEntries
+				} else {
+					_, err := controlplane.InvokeRequest(cmd.Context(), http.MethodGet, fmt.Sprintf("v1/buffers/%s", args[0]), nil, &buffer)
+					if err != nil {
+						return err
+					}
 
-			fmt.Println(string(formattedBuffer))
-			return nil
+					if etag != "" && etag != buffer.ETag {
+						return fmt.Errorf("the server's ETag does not match the provided ETag")
+					}
+
+					requestEtag = buffer.ETag
+
+					newTagEntries = make(map[string]string)
+					for k, v := range buffer.Tags {
+						newTagEntries[k] = v
+					}
+
+					for k, v := range tagEntries {
+						newTagEntries[k] = v
+					}
+				}
+
+				if etag != "" {
+					headers.Set("If-Match", requestEtag)
+				}
+
+				resp, err := controlplane.InvokeRequest(cmd.Context(), http.MethodPut, fmt.Sprintf("v1/buffers/%s/tags", args[0]), Tags(newTagEntries), &buffer, controlplane.WithHeaders(headers))
+
+				if resp.StatusCode == http.StatusPreconditionFailed {
+					if etag == "" {
+						continue
+					}
+					return fmt.Errorf("the server's ETag does not match the provided ETag")
+				}
+
+				if err != nil {
+					return err
+				}
+
+				formattedBuffer, err := json.MarshalIndent(buffer, "", "  ")
+				if err != nil {
+					return err
+				}
+
+				fmt.Println(string(formattedBuffer))
+				return nil
+			}
 		},
 	}
+
+	cmd.Flags().BoolVar(&clearTags, "clear-tags", clearTags, "clear all existing tags from the buffer and replace them with the new tags. If not specified, the existing tags are preserved and updated.")
+	cmd.Flags().StringToStringVar(&tagEntries, "tag", nil, "add or update a key-value tag to the buffer. Can be specified multiple times.")
 	cmd.Flags().StringVar(&etag, "etag", etag, "the ETag read ETag to guard against concurrent updates, ")
-	cmd.Flags().StringToStringVar(&tagEntries, "tag", nil, "add a key-value tag to the buffer. Can be specified multiple times.")
 
 	return cmd
 }

--- a/docs/guides/buffers.md
+++ b/docs/guides/buffers.md
@@ -82,7 +82,7 @@ Buffers can be tagged with key-value metadata pairs. You can assign tags to a
 buffer when creating it like this:
 
 ```bash
-tyger buffer create --tag mykey1=myvalue1 --tag mykey2=myvalue2
+buffer_id=$(tyger buffer create --tag mykey1=myvalue1 --tag mykey2=myvalue2)
 ```
 
 You can view the tags on a buffer with:
@@ -105,21 +105,38 @@ The response looks like:
 }
 ```
 
-Replace a buffer's tags with:
+Update a buffer's tags with:
 
 ```bash
-tyger buffer set $buffer_id --tag newkey=newvalue
+tyger buffer set $buffer_id --tag myKey1=myvalue1Updated --tag mykey3=myvalue3
 ```
-
-Note: This **replaces** all existing tags.
 
 ```json
 {
-  "id": "362z6u2h7voevic7zt3kkhpwxm",
+  "id": "yf4sx2aqzitepjhmxjhanomn5e",
   "etag": "638418039170119977",
-  "createdAt": "2024-01-25T18:19:55.423949Z",
+  "createdAt": "2024-01-25T18:20:49.951262Z",
   "tags": {
-    "newkey": "newvalue"
+    "myKey1": "myvalue1Updated",
+    "mykey2": "myvalue2",
+    "mykey3": "myvalue3"
+  }
+}
+```
+
+To replace the **entire** set of tags, specify `--clear-tags`:
+
+```bash
+tyger buffer set $buffer_id --clear-tags --tag myKey1=yetAnotherValue
+```
+
+```json
+{
+  "id": "yf4sx2aqzitepjhmxjhanomn5e",
+  "etag": "638418039170119988",
+  "createdAt": "2024-01-25T18:20:49.951262Z",
+  "tags": {
+    "myKey1": "yetAnotherValue",
   }
 }
 ```


### PR DESCRIPTION
`tyger buffer ID set --tag x=y` will now "upsert" the tag x=y but not change any other tags. Use `--clear-tags` to replace the entire set of tags.