### PR TITLE
Add option to display service metadata

### DIFF
--- a/cli/internal/controlplane/model/model.go
+++ b/cli/internal/controlplane/model/model.go
@@ -13,9 +13,9 @@ import (
 )
 
 type ServiceMetadata struct {
-	Authority      string   `json:"authority"`
-	Audience       string   `json:"audience"`
-	CliAppUri      string   `json:"cliAppUri"`
+	Authority      string   `json:"authority,omitempty"`
+	Audience       string   `json:"audience,omitempty"`
+	CliAppUri      string   `json:"cliAppUri,omitempty"`
 	DataPlaneProxy string   `json:"dataPlaneProxy,omitempty"`
 	Capabilities   []string `json:"capabilities,omitempty"`
 }


### PR DESCRIPTION
```
tyger login status --format json
````

will display connection and service metadata in JSON format:

``` json
{
  "serverUri": "https://abc-tyger.westus2.cloudapp.azure.com",
  "principal": "api://tyger-test-client",
  "metadata": {
    "authority": "https://login.microsoftonline.com/76d3279b-830e-4bea-baf8-12863cdeba4c",
    "audience": "api://tyger-server",
    "cliAppUri": "api://tyger-cli",
    "capabilities": [
      "NodePools",
      "DistributedRuns"
    ]
  }
}
```