### PR TITLE
Allow SSH options to be given in login URL

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,7 +55,7 @@
       "mode": "auto",
       "program": "cli/cmd/tyger",
       "cwd": "${workspaceFolder}",
-      "args": ["buffer", "write", "http+unix:///tmp/xyz?relay=true"],
+      "args": ["login", "status", "--format", "json"],
       "env": {
         "TYGER_CACHE_FILE": "/home/vscode/.cache/tyger/.tyger-docker"
       },

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel v1.28.0
 	golang.org/x/sync v0.7.0
+	golang.org/x/term v0.21.0
 	helm.sh/helm/v3 v3.14.3
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3
@@ -177,7 +178,6 @@ require (
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
-	golang.org/x/term v0.21.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect

--- a/cli/internal/client/sshurl.go
+++ b/cli/internal/client/sshurl.go
@@ -121,10 +121,10 @@ func (sp *SshParams) formatCmdLine(sshOptions map[string]string, otherSshArgs []
 		combinedSshOptions = sp.Options
 	} else {
 		combinedSshOptions = make(map[string]string)
-		for k, v := range sp.Options {
+		for k, v := range sshOptions {
 			combinedSshOptions[k] = v
 		}
-		for k, v := range sshOptions {
+		for k, v := range sp.Options {
 			combinedSshOptions[k] = v
 		}
 	}

--- a/cli/internal/client/sshurl.go
+++ b/cli/internal/client/sshurl.go
@@ -6,10 +6,13 @@ package client
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"runtime"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Parses and formats ssh:// URLs
@@ -20,6 +23,7 @@ type SshParams struct {
 	User       string
 	SocketPath string
 	CliPath    string
+	Options    map[string]string
 }
 
 func ParseSshUrl(u *url.URL) (*SshParams, error) {
@@ -48,8 +52,16 @@ func ParseSshUrl(u *url.URL) (*SshParams, error) {
 			queryParams.Del("cliPath")
 		}
 
-		if len(queryParams) > 0 {
-			return nil, errors.Errorf("unexpected query parameters: %v. Only 'cliPath' is supported", queryParams)
+		for k, v := range queryParams {
+			if strings.HasPrefix(k, "option[") && strings.HasSuffix(k, "]") {
+				name := k[7 : len(k)-1]
+				if sp.Options == nil {
+					sp.Options = make(map[string]string)
+				}
+				sp.Options[name] = v[0]
+			} else {
+				return nil, errors.Errorf("unexpected query parameter: %q. Only 'cliPath' and 'option[<SSH_OPTION>]' are suported", k)
+			}
 		}
 	}
 
@@ -77,9 +89,15 @@ func (sp *SshParams) URL() *url.URL {
 	if sp.Port != "" {
 		u.Host += ":" + sp.Port
 	}
+	q := u.Query()
 	if sp.CliPath != "" {
-		q := u.Query()
 		q.Set("cliPath", sp.CliPath)
+	}
+	for k, v := range sp.Options {
+		q.Set(fmt.Sprintf("option[%s]", k), v)
+	}
+
+	if len(q) > 0 {
 		u.RawQuery = q.Encode()
 	}
 
@@ -87,11 +105,33 @@ func (sp *SshParams) URL() *url.URL {
 }
 
 func (sp *SshParams) FormatCmdLine(add ...string) []string {
-	return sp.formatCmdLine(nil, add...)
+	sshOptions := map[string]string{
+		"StrictHostKeyChecking": "yes",
+	}
+	return sp.formatCmdLine(sshOptions, nil, add...)
 }
 
-func (sp *SshParams) formatCmdLine(sshArgs []string, cmdArgs ...string) []string {
+func (sp *SshParams) formatCmdLine(sshOptions map[string]string, otherSshArgs []string, cmdArgs ...string) []string {
 	args := []string{sp.Host}
+
+	var combinedSshOptions map[string]string
+	if sp.Options == nil {
+		combinedSshOptions = sshOptions
+	} else if sshOptions == nil {
+		combinedSshOptions = sp.Options
+	} else {
+		combinedSshOptions = make(map[string]string)
+		for k, v := range sp.Options {
+			combinedSshOptions[k] = v
+		}
+		for k, v := range sshOptions {
+			combinedSshOptions[k] = v
+		}
+	}
+
+	for k, v := range combinedSshOptions {
+		args = append(args, "-o", fmt.Sprintf("%s=%s", k, v))
+	}
 
 	if sp.User != "" {
 		args = append(args, "-l", sp.User)
@@ -100,7 +140,7 @@ func (sp *SshParams) formatCmdLine(sshArgs []string, cmdArgs ...string) []string
 		args = append(args, "-p", sp.Port)
 	}
 
-	args = append(args, sshArgs...)
+	args = append(args, otherSshArgs...)
 
 	args = append(args, "--")
 
@@ -117,11 +157,19 @@ func (sp *SshParams) formatCmdLine(sshArgs []string, cmdArgs ...string) []string
 }
 
 func (sp *SshParams) FormatLoginArgs(add ...string) []string {
+	var sshOptions map[string]string
+	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+		// avoid interactive prompt
+		sshOptions = map[string]string{
+			"StrictHostKeyChecking": "yes",
+		}
+	}
+
 	// Disable stdin and disable pseudo-terminal allocation.
 	// On Windows, we can get a hang when the remote process exits quickly because
 	// the SSH process is waiting for Enter to be pressed.
 
-	sshArgs := []string{"-nT"}
+	otherSshArgs := []string{"-nT"}
 	args := []string{"login"}
 
 	if sp.SocketPath != "" {
@@ -129,19 +177,20 @@ func (sp *SshParams) FormatLoginArgs(add ...string) []string {
 	}
 
 	args = append(args, add...)
-	return sp.formatCmdLine(sshArgs, args...)
+	return sp.formatCmdLine(sshOptions, otherSshArgs, args...)
 }
 
 func (sp *SshParams) FormatDataPlaneCmdLine(add ...string) []string {
-	var sshArgs []string
-	if runtime.GOOS != "windows" {
-		// create a dedicated control socket for this process
-		sshArgs = []string{
-			"-o", "ControlMaster=auto",
-			"-o", fmt.Sprintf("ControlPath=/tmp/%s", uuid.New().String()),
-			"-o", "ControlPersist=2m",
-		}
+	sshOptions := map[string]string{
+		"StrictHostKeyChecking": "yes",
 	}
 
-	return sp.formatCmdLine(sshArgs, add...)
+	if runtime.GOOS != "windows" {
+		// create a dedicated control socket for this process
+		sshOptions["ControlMaster"] = "auto"
+		sshOptions["ControlPath"] = fmt.Sprintf("/tmp/%s", uuid.New().String())
+		sshOptions["ControlPersist"] = "2m"
+	}
+
+	return sp.formatCmdLine(sshOptions, nil, add...)
 }

--- a/cli/internal/client/sshurl.go
+++ b/cli/internal/client/sshurl.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // Parses and formats ssh:// URLs
@@ -158,7 +158,7 @@ func (sp *SshParams) formatCmdLine(sshOptions map[string]string, otherSshArgs []
 
 func (sp *SshParams) FormatLoginArgs(add ...string) []string {
 	var sshOptions map[string]string
-	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		// avoid interactive prompt
 		sshOptions = map[string]string{
 			"StrictHostKeyChecking": "yes",

--- a/cli/internal/cmd/run.go
+++ b/cli/internal/cmd/run.go
@@ -870,7 +870,9 @@ func pullImages(ctx context.Context, newRun model.Run) error {
 
 			// Capture SSH options
 			defaultArgs := sshParams.FormatCmdLine()
-			optionArgs := make([]string, 0)
+			optionArgs := []string{
+				"-o", "ConnectTimeout=none", // The default of 30s that docker adds can cause a _hang_ of 30s: https://github.com/PowerShell/Win32-OpenSSH/issues/1352
+			}
 			for i := 0; i < len(defaultArgs); i++ {
 				if defaultArgs[i] == "-o" {
 					optionArgs = append(optionArgs, defaultArgs[i], defaultArgs[i+1])

--- a/cli/internal/cmd/run.go
+++ b/cli/internal/cmd/run.go
@@ -868,9 +868,22 @@ func pullImages(ctx context.Context, newRun model.Run) error {
 				return fmt.Errorf("failed to parse SSH URL: %w", err)
 			}
 
+			// Capture SSH options
+			defaultArgs := sshParams.FormatCmdLine()
+			optionArgs := make([]string, 0)
+			for i := 0; i < len(defaultArgs); i++ {
+				if defaultArgs[i] == "-o" {
+					optionArgs = append(optionArgs, defaultArgs[i], defaultArgs[i+1])
+					i++
+				}
+			}
+
+			// clear fields that result in a URI that docker won't underatand
 			sshParams.CliPath = ""
 			sshParams.SocketPath = ""
-			connhelper, err := connhelper.GetConnectionHelper(sshParams.URL().String())
+			sshParams.Options = nil
+
+			connhelper, err := connhelper.GetConnectionHelperWithSSHOpts(sshParams.URL().String(), optionArgs)
 			if err != nil {
 				return fmt.Errorf("failed to get connection helper: %w", err)
 			}

--- a/docs/introduction/installation/docker-installation.md
+++ b/docs/introduction/installation/docker-installation.md
@@ -149,13 +149,19 @@ not a password.
 The format of the SSH URL is:
 
 ```
-ssh://[user@]host[:port][?cliPath=/path/to/tyger]
+ssh://[user@]host[:port][?key1=value1&key2=value2]
 ```
 
 All values in `[]` are optional. The user and port default values will come from
-your SSH config file (~/.ssh/config). The `cliPath` query parameter only needs
-to be specified if `tyger` is not installed in a directory in the SSH host's
-$PATH variable.
+your SSH config file (~/.ssh/config). Additional parameters can be passed in
+as query parameters (after the `?`). These are:
+
+ - `cliPath`, to speciy that path to the `tyger` CLI on the host. This is only
+necessary if the localtion is not part of the `PATH` variable.
+- `option[sshConfigKey]`, to specify additional SSH
+[configuration options](https://www.man7.org/linux/man-pages/man5/ssh_config.5.html).
+For example, `ssh://myhost?option[StrictHostChecking]=no` results in a SSH command
+that looks like `ssh myhost -o StrictHostChecking=no`
 
 For the best user experience with SSH, configure ~/.ssh/config as follows to
 allow reusing a SSH connection for multiple invocations of the `tyger` CLI:

--- a/scripts/run-ssh-tests.sh
+++ b/scripts/run-ssh-tests.sh
@@ -110,7 +110,6 @@ Host $ssh_host
   HostName $ssh_connection_host
   Port $ssh_connection_port
   User $ssh_user
-  StrictHostKeyChecking no
   ControlMaster auto
   ControlPath  ~/.ssh/control-%C
   ControlPersist  yes
@@ -127,7 +126,7 @@ ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "$ssh_connection_host"
 
 max_attempts=30
 attempts=0
-until ssh $ssh_host true &>/dev/null || [ $attempts -eq $max_attempts ]; do
+until ssh $ssh_host -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null true &>/dev/null || [ $attempts -eq $max_attempts ]; do
     echo "Waiting for SSH server to be ready..."
     sleep 1
     attempts="$((attempts + 1))"
@@ -143,7 +142,7 @@ echo "SSH server is ready"
 TYGER_CACHE_FILE=$(mktemp)
 export TYGER_CACHE_FILE
 
-tyger login ssh://$ssh_host
+tyger login "ssh://$ssh_host?option[StrictHostKeyChecking]=no"
 tyger login status
 
 if [[ -z ${start_only:-} ]]; then


### PR DESCRIPTION
Allow SSH config options to be given in the SSH tyger URI, e.g. `ssh://myhost?option[StrictHostChecking]=no`. Also default `StrictHostChecking` to `yes` except for the initial login call (unless not running in a terminal, so that the prompt doesn't result in a hang).