### PR TITLE
Add common flags to `tyger identities install` command

### DIFF
--- a/cli/internal/cmd/install/identities.go
+++ b/cli/internal/cmd/install/identities.go
@@ -75,5 +75,7 @@ func newIdentitiesInstallCommand() *cobra.Command {
 		},
 	}
 
+	addCommonFlags(cmd, &flags)
+
 	return cmd
 }


### PR DESCRIPTION
In an earlier refactoring, I missed adding the mandatory `-f` flag to `tyger identities install`.