### PR TITLE
Use images published to MCR

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -282,27 +282,6 @@ jobs:
           set -euo pipefail
           make -s integration-test-no-up
 
-  publish-official-images:
-    needs:
-      - test-azure-needs-hosted-runner
-    runs-on: ${{ fromJson(needs.test-azure-needs-hosted-runner.outputs.AZURE_RUNS_ON_JSON)}}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Log in to Azure
-        uses: ./.github/actions/login-azure
-
-      - name: Publish official images
-        run: |
-          set -euo pipefail
-          make publish-official-images
-
   build-windows-binaries:
     runs-on: ubuntu-latest
     defaults:
@@ -539,8 +518,10 @@ jobs:
       - name: get container registry
         run: |
           set -euo pipefail
-          official_container_registry=$(echo "$DEVELOPER_CONFIG_BASE64" | base64 -d | jq -r '.officialContainerRegistry.fqdn')
-          echo "OFFICIAL_CONTAINER_REGISTRY=$(echo $official_container_registry)" >> $GITHUB_ENV
+          official_pull_container_registry=$(echo "$DEVELOPER_CONFIG_BASE64" | base64 -d | jq -r '.officialPullContainerRegistry.fqdn')
+          echo "OFFICIAL_PULL_CONTAINER_REGISTRY=$(echo $official_pull_container_registry)" >> $GITHUB_ENV
+          official_pull_container_registry_directory=$(echo "$DEVELOPER_CONFIG_BASE64" | base64 -d | jq -r '.officialPullContainerRegistry.directory // ""')
+          echo "OFFICIAL_PULL_CONTAINER_REGISTRY_DIRECTORY=$(echo $official_pull_container_registry_directory)" >> $GITHUB_ENV
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -11,7 +11,8 @@ builds:
     ldflags:
       - -s -w
       - -X main.version={{ .Tag }}
-      - -X github.com/microsoft/tyger/cli/internal/install.ContainerRegistry={{ .Env.OFFICIAL_CONTAINER_REGISTRY }}
+      - -X github.com/microsoft/tyger/cli/internal/install.ContainerRegistry={{ .Env.OFFICIAL_PULL_CONTAINER_REGISTRY }}
+      - -X github.com/microsoft/tyger/cli/internal/install.ContainerRegistryDirectory={{ .Env.OFFICIAL_PULL_CONTAINER_REGISTRY_DIRECTORY }}
       - -X github.com/microsoft/tyger/cli/internal/install.ContainerImageTag={{ .Tag }}
     goos:
       - linux

--- a/cli/internal/install/cloudinstall/config.tpl
+++ b/cli/internal/install/cloudinstall/config.tpl
@@ -111,7 +111,7 @@ api:
   #   tyger:
   #     repoName:
   #     repoUrl: # not set if using `chartRef`
-  #     chartRef: # e.g. oci://tyger.azurecr.io/helm/tyger
+  #     chartRef: # e.g. oci://mcr.microsoft.com/tyger/helm/tyger
   #     namespace:
   #     version:
   #     values:

--- a/cli/internal/install/cloudinstall/helm.go
+++ b/cli/internal/install/cloudinstall/helm.go
@@ -321,14 +321,6 @@ func (inst *Installer) InstallTyger(ctx context.Context) error {
 }
 
 func (inst *Installer) InstallTygerHelmChart(ctx context.Context, restConfig *rest.Config, dryRun bool) (manifest string, valuesYaml string, err error) {
-	if install.ContainerRegistry == "" {
-		panic("officialContainerRegistry not set during build")
-	}
-
-	if install.ContainerImageTag == "" {
-		panic("officialContainerImageTag not set during build")
-	}
-
 	clustersConfigJson, err := json.Marshal(inst.Config.Cloud.Compute.Clusters)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to marshal cluster configuration: %w", err)
@@ -412,13 +404,13 @@ func (inst *Installer) InstallTygerHelmChart(ctx context.Context, restConfig *re
 	helmConfig := HelmChartConfig{
 		Namespace:   TygerNamespace,
 		ReleaseName: DefaultTygerReleaseName,
-		ChartRef:    fmt.Sprintf("oci://%s/helm/tyger", install.ContainerRegistry),
+		ChartRef:    fmt.Sprintf("oci://%s%shelm/tyger", install.ContainerRegistry, install.GetNormalizedContainerRegistryDirectory()),
 		Version:     install.ContainerImageTag,
 		Values: map[string]any{
-			"image":              fmt.Sprintf("%s/tyger-server:%s", install.ContainerRegistry, install.ContainerImageTag),
-			"bufferSidecarImage": fmt.Sprintf("%s/buffer-sidecar:%s", install.ContainerRegistry, install.ContainerImageTag),
-			"bufferCopierImage":  fmt.Sprintf("%s/buffer-copier:%s", install.ContainerRegistry, install.ContainerImageTag),
-			"workerWaiterImage":  fmt.Sprintf("%s/worker-waiter:%s", install.ContainerRegistry, install.ContainerImageTag),
+			"image":              fmt.Sprintf("%s%styger-server:%s", install.ContainerRegistry, install.GetNormalizedContainerRegistryDirectory(), install.ContainerImageTag),
+			"bufferSidecarImage": fmt.Sprintf("%s%sbuffer-sidecar:%s", install.ContainerRegistry, install.GetNormalizedContainerRegistryDirectory(), install.ContainerImageTag),
+			"bufferCopierImage":  fmt.Sprintf("%s%sbuffer-copier:%s", install.ContainerRegistry, install.GetNormalizedContainerRegistryDirectory(), install.ContainerImageTag),
+			"workerWaiterImage":  fmt.Sprintf("%s%sworker-waiter:%s", install.ContainerRegistry, install.GetNormalizedContainerRegistryDirectory(), install.ContainerImageTag),
 			"hostname":           inst.Config.Api.DomainName,
 			"identity": map[string]any{
 				"tygerServer": map[string]any{

--- a/cli/internal/install/dockerinstall/validation.go
+++ b/cli/internal/install/dockerinstall/validation.go
@@ -154,7 +154,7 @@ func (inst *Installer) QuickValidateConfig() bool {
 }
 
 func defaultImage(repo string) string {
-	return fmt.Sprintf("%s/%s:%s", install.ContainerRegistry, repo, install.ContainerImageTag)
+	return fmt.Sprintf("%s%s%s:%s", install.ContainerRegistry, install.GetNormalizedContainerRegistryDirectory(), repo, install.ContainerImageTag)
 }
 
 func validationError(success *bool, format string, args ...any) {

--- a/cli/internal/install/installer.go
+++ b/cli/internal/install/installer.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
+	"sync"
 )
 
 var (
@@ -15,11 +17,21 @@ var (
 )
 
 var (
-	// Set during build but we provide defaults so that there is some value when debugging.
-	// We will need to update these from time to time. Alternatively, you can set the registry
-	// values using the --set command-line argument.
-	ContainerRegistry string = "tyger.azurecr.io"
-	ContainerImageTag string = "v0.4.0-112-g428a5e8"
+	// Set during build
+	ContainerRegistry          string = ""
+	ContainerRegistryDirectory string = ""
+	ContainerImageTag          string = ""
+
+	GetNormalizedContainerRegistryDirectory = sync.OnceValue(func() string {
+		normalized := ContainerRegistryDirectory
+		if !strings.HasPrefix(normalized, "/") {
+			normalized = "/" + normalized
+		}
+		if !strings.HasSuffix(normalized, "/") {
+			normalized = normalized + "/"
+		}
+		return normalized
+	})
 )
 
 type Installer interface {

--- a/deploy/config/microsoft/devconfig.yml
+++ b/deploy/config/microsoft/devconfig.yml
@@ -1,10 +1,12 @@
 subscriptionId: 87d8acb3-5176-4651-b457-6ab9cefd8e3d
 wipContainerRegistry:
-  name: eminence
   fqdn: eminence.azurecr.io
-officialContainerRegistry:
-  name: tyger
-  fqdn: tyger.azurecr.io
+officialPushContainerRegistry:
+  fqdn: tygerprod.azurecr.io
+  directory: /public/tyger
+officialPullContainerRegistry:
+  fqdn: mcr.microsoft.com
+  directory: /tyger
 keyVault: eminence
 testAppUri: api://tyger-test-client
 pemCertSecret:

--- a/docs/introduction/installation/cloud-installation.md
+++ b/docs/introduction/installation/cloud-installation.md
@@ -157,7 +157,7 @@ api:
   #   tyger:
   #     repoName:
   #     repoUrl: # not set if using `chartRef`
-  #     chartRef: # e.g. oci://tyger.azurecr.io/helm/tyger
+  #     chartRef: # e.g. oci://mcr.microsoft.com/tyger/helm/tyger
   #     namespace:
   #     version:
   #     values: # Helm values overrides
@@ -175,7 +175,7 @@ command-line with `--set`. For example:
 
 ```bash
 tyger api install -f config.yml \
-  --set api.helm.tyger.chartRef=oci://tyger.azurecr.io/helm/tyger \
+  --set api.helm.tyger.chartRef=oci://mcr.microsoft.com/tyger/helm/tyger \
   --set api.helm.tyger.version=v0.4.0
 ```
 
@@ -216,7 +216,7 @@ tyger api install -f config.yml
 ```
 
 This command installs the Tyger API from the Helm chart in the
-`tyger.azurecr.io/helm/tyger` registry, using a version baked into the `tyger`
+`mcr.microsoft.com/tyger/helm/tyger` registry, using a version baked into the `tyger`
 CLI. Upgrade the server by updating the CLI and rerunning `tyger api install`.
 
 The API's TLS certificate is automatically created using [Let's


### PR DESCRIPTION
When publishing releases, we will publish container images to `mcr.microsoft.com/tyger`. The actual publishing is done outside of this repo.