### PR TITLE
Remove Docker Desktop workaround

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -101,7 +101,6 @@
   "containerEnv": {
     "DOCKER_BUIKDKIT": "1",
     "DEVCONTAINER_HOST_HOME": "${localEnv:HOME}",
-    "WSL_DISTRO_NAME": "${localEnv:WSL_DISTRO_NAME}",
     "TYGER_ACCESSING_FROM_DOCKER": "1"
   },
 

--- a/.devcontainer/prepare-host.sh
+++ b/.devcontainer/prepare-host.sh
@@ -18,3 +18,14 @@ fi
 if [ ! -d /tmp/tyger ]; then
     mkdir -m 777 /tmp/tyger
 fi
+
+if [ -n "${WSL_DISTRO_NAME:-}" ]; then
+    minimum_docker_desktop_version="4.31.0"
+
+    docker_version=$(docker.exe version | grep -oP 'Server: Docker Desktop \d+\.\d+(\.\d+)?')
+    docker_version=$(echo "$docker_version" | grep -oP '\d+\.\d+(\.\d+)?')
+    if [ "$(printf '%s\n' $minimum_docker_desktop_version "$docker_version" | sort -V | head -n1)" != $minimum_docker_desktop_version ]; then
+        echo "Docker Desktop version $docker_version is not supported. Please upgrade to version $minimum_docker_desktop_version or later."
+        exit 1
+    fi
+fi

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -24,7 +24,6 @@ set-localsettings: ensure-data-plane-cert
 				"docker": {
 					"runSecretsPath": "$${run_secrets_path}",
 					"ephemeralBuffersPath": "$${ephemeral_buffers_path}",
-					"wslDistroName": "$${WSL_DISTRO_NAME}",
 					"networkName": "tyger-local-network"
 				}
 			},
@@ -43,6 +42,7 @@ set-localsettings: ensure-data-plane-cert
 			},
 			"database": {
 				"host": "/opt/tyger/database",
+				"username": "tyger-server",
 				"databaseName": "tyger-server",
 				"autoMigrate": "true",
 				"tygerServerRoleName": "tyger-server"

--- a/cli/internal/install/dockerinstall/config.tpl
+++ b/cli/internal/install/dockerinstall/config.tpl
@@ -35,4 +35,3 @@ signingKeys:
 # dataPlaneImage:
 # bufferSidecarImage:
 # gatewayImage:
-# gatewayImage:

--- a/scripts/run-ssh-tests.sh
+++ b/scripts/run-ssh-tests.sh
@@ -29,19 +29,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-wsl_host_path() {
-    if [[ -z "${WSL_DISTRO_NAME:-}" ]]; then
-        echo "$1"
-        return
-    fi
-
-    # replace / with \
-    path=${1//\//\\}
-
-    # shellcheck disable=SC2028
-    echo "\\\\wsl$\\${WSL_DISTRO_NAME}${path}"
-}
-
 cleanup_ssh_config() {
     if [[ -f "${HOME}/.ssh/config" ]]; then
         sed -i "/$start_marker/,/$end_marker/d" "${HOME}/.ssh/config"
@@ -63,8 +50,8 @@ docker create \
     -p $ssh_port:22 \
     -e "SSH_ENABLE_ROOT=true" \
     -e "TCP_FORWARDING=true" \
-    -v "$(wsl_host_path "/opt/tyger"):/opt/tyger" \
-    -v "$(wsl_host_path "/var/run/docker.sock"):/var/run/docker.sock" \
+    -v "/opt/tyger:/opt/tyger" \
+    -v "/var/run/docker.sock:/var/run/docker.sock" \
     --name $container_name \
     quay.io/panubo/sshd:1.8.0 >/dev/null
 

--- a/server/ControlPlane/Compute/Docker/Docker.cs
+++ b/server/ControlPlane/Compute/Docker/Docker.cs
@@ -48,8 +48,6 @@ public class DockerOptions
 
     public bool GpuSupport { get; set; }
 
-    public string? WslDistroName { get; set; }
-
     [Required]
     public required string NetworkName { get; set; }
 }


### PR DESCRIPTION
Version 4.31.0 of Docker Desktop fixed an issue introduced in 4.28 regarding Docker-in-Docker scenarios that we had a workaround for. That fix broke the workaround, so we remove it and add a version check installation time.