### PR TITLE
Record run start time

### DIFF
--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -103,11 +103,16 @@ func TestEndToEnd(t *testing.T) {
 		"-b", fmt.Sprintf("input=%s", inputBufferId),
 		"-b", fmt.Sprintf("output=%s", outputBufferId))
 
-	waitForRunSuccess(t, runId)
+	run := waitForRunSuccess(t, runId)
 
 	output := runCommandSucceeds(t, "sh", "-c", fmt.Sprintf(`tyger buffer read "%s"`, outputSasUri))
 
 	require.Equal("Hello: Bonjour", output)
+
+	require.NotNil(run.StartedAt)
+	require.GreaterOrEqual(*run.StartedAt, run.CreatedAt)
+	require.NotNil(run.FinishedAt)
+	require.GreaterOrEqual(*run.FinishedAt, *run.StartedAt)
 }
 
 func TestEndToEndWithAutomaticallyCreatedBuffers(t *testing.T) {

--- a/cli/integrationtest/expected_openapi_spec.yaml
+++ b/cli/integrationtest/expected_openapi_spec.yaml
@@ -747,6 +747,11 @@ components:
           description: The time the run was created. Populated by the system.
           format: date-time
           nullable: true
+        startedAt:
+          type: string
+          description: The time the run's job started. Populated by the system.
+          format: date-time
+          nullable: true
         finishedAt:
           type: string
           description: The time the run finished. Populated by the system.

--- a/cli/internal/controlplane/model/model.go
+++ b/cli/internal/controlplane/model/model.go
@@ -207,6 +207,7 @@ type RunMetadata struct {
 	StatusReason string     `json:"statusReason,omitempty"`
 	RunningCount *int       `json:"runningCount,omitempty"`
 	CreatedAt    time.Time  `json:"createdAt,omitempty"`
+	StartedAt    *time.Time `json:"startedAt,omitempty"`
 	FinishedAt   *time.Time `json:"finishedAt,omitempty"`
 }
 

--- a/cli/internal/dataplane/relayserver.go
+++ b/cli/internal/dataplane/relayserver.go
@@ -58,6 +58,14 @@ func RelayInputServer(
 			}
 
 			defer complete()
+
+			defer func() {
+				flusher, ok := w.(http.Flusher)
+				if ok {
+					flusher.Flush()
+				}
+			}()
+
 			if outputWriter == io.Discard {
 				log.Warn().Msg("Discarding input data")
 				w.WriteHeader(http.StatusAccepted)
@@ -119,6 +127,13 @@ func RelayOutputServer(
 				return
 			}
 			defer complete()
+
+			defer func() {
+				flusher, ok := w.(http.Flusher)
+				if ok {
+					flusher.Flush()
+				}
+			}()
 
 			_, err := io.Copy(w, inputReader)
 			if err != nil {

--- a/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
+++ b/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
@@ -120,8 +120,7 @@ public partial class DockerRunCreator : RunCreatorBase, IRunCreator, IHostedServ
         run = await Repository.CreateRun(run, idempotencyKey, cancellationToken);
 
         var bufferMap = await GetBufferMap(jobCodespec.Buffers, run.Job.Buffers!, cancellationToken);
-
-        string mainContainerName = $"tyger-run-{run.Id}-main";
+        string mainContainerName = MainContainerName(run.Id!.Value);
 
         if (run.Job.Buffers != null)
         {
@@ -469,6 +468,11 @@ public partial class DockerRunCreator : RunCreatorBase, IRunCreator, IHostedServ
 
         _logger.CreatedRun(run.Id!.Value);
         return run with { Status = RunStatus.Running };
+    }
+
+    internal static string MainContainerName(long runId)
+    {
+        return $"tyger-run-{runId}-main";
     }
 
     private async Task CreateAndStartContainer(CreateContainerParameters sidecarContainerParameters, CancellationToken cancellationToken)

--- a/server/ControlPlane/Database/Repository.cs
+++ b/server/ControlPlane/Database/Repository.cs
@@ -523,7 +523,7 @@ public class Repository : IRepository
 
             var runJson = reader.GetString(0);
             var run = JsonSerializer.Deserialize<Run>(runJson, _serializerOptions) ?? throw new InvalidOperationException("Failed to deserialize run.");
-            updatedRun = run with { Status = state.Status, StatusReason = state.StatusReason, RunningCount = state.RunningCount, FinishedAt = state.FinishedAt, Job = run.Job with { NodePool = state.JobNodePool }, Worker = run.Worker == null ? null : run.Worker with { NodePool = state.WorkerNodePool } };
+            updatedRun = state.ApplyToRun(run);
             if (updatedRun.Equals(run))
             {
                 return;

--- a/server/ControlPlane/Model/Model.cs
+++ b/server/ControlPlane/Model/Model.cs
@@ -452,6 +452,11 @@ public record Run : ModelBase
     public DateTimeOffset? CreatedAt { get; init; }
 
     /// <summary>
+    /// The time the run's job started. Populated by the system.
+    /// </summary>
+    public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>
     /// The time the run finished. Populated by the system.
     /// </summary>
     public DateTimeOffset? FinishedAt { get; init; }
@@ -486,6 +491,7 @@ public record Run : ModelBase
             StatusReason = null,
             RunningCount = null,
             CreatedAt = default,
+            StartedAt = default,
             FinishedAt = null,
         };
     }

--- a/server/ControlPlane/Model/ObservedRunState.cs
+++ b/server/ControlPlane/Model/ObservedRunState.cs
@@ -25,6 +25,7 @@ public partial record struct ObservedRunState(
     {
         StatusReason = run.StatusReason;
         RunningCount = run.RunningCount;
+        StartedAt = run.StartedAt;
         FinishedAt = run.FinishedAt;
         JobNodePool = run.Job.NodePool;
         WorkerNodePool = run.Worker?.NodePool;
@@ -34,6 +35,8 @@ public partial record struct ObservedRunState(
     public string? StatusReason { get; init; }
 
     public int? RunningCount { get; init; }
+
+    public DateTimeOffset? StartedAt { get; init; }
 
     public DateTimeOffset? FinishedAt { get; init; }
 
@@ -51,6 +54,7 @@ public partial record struct ObservedRunState(
             Status = Status,
             StatusReason = StatusReason,
             RunningCount = RunningCount,
+            StartedAt = StartedAt,
             FinishedAt = FinishedAt,
             Job = run.Job with { NodePool = JobNodePool },
             Worker = run.Worker == null ? null : run.Worker with { NodePool = WorkerNodePool }


### PR DESCRIPTION
- Record start time for runs.
- Handle the case where the finish time of Kubernetes containers is [unknown](https://github.com/kubernetes/kubernetes/issues/104107). 
- Improve the reliability of ephemeral buffer transfers.