### PR TITLE
Prefetch AKS token

### DIFF
--- a/.github/actions/login-azure/action.yml
+++ b/.github/actions/login-azure/action.yml
@@ -57,3 +57,4 @@ runs:
           az account get-access-token --scope https://storage.azure.com/.default --output none
           az account get-access-token --scope https://vault.azure.net/.default --output none
           az account get-access-token --resource https://ossrdbms-aad.database.windows.net --output none
+          az account get-access-token --resource 6dae42f8-4368-4678-94ff-3960e28e3630 --output none # AKS https://azure.github.io/kubelogin/concepts/aks.html


### PR DESCRIPTION
PR pipelines routinely fail because the federated credentials expire after 5 minutes. Add another workaround where we pre-prefetch an AKS token.