### PR TITLE
Fix `tyger run cancel` race condition

### DIFF
--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -1311,10 +1311,6 @@ func TestCancelJob(t *testing.T) {
 
 	runTygerSucceeds(t, "run", "cancel", runId)
 
-	// force the sweep to run to terminate the pod
-	_, err := controlplane.InvokeRequest(context.Background(), http.MethodPost, "v1/runs/_sweep", nil, nil)
-	require.NoError(err)
-
 	waitForRunCanceled(t, runId)
 
 	// Check that the run failed because it was canceled.

--- a/cli/internal/cmd/run.go
+++ b/cli/internal/cmd/run.go
@@ -311,7 +311,9 @@ beginWatch:
 	}
 
 end:
-	mainWg.Wait()
+	if runFailedErr == nil {
+		mainWg.Wait()
+	}
 
 	if logs {
 		// The run has completed and we have received all data. We just need to wait for the logs to finish streaming,

--- a/server/ControlPlane/Database/Repository.cs
+++ b/server/ControlPlane/Database/Repository.cs
@@ -534,7 +534,7 @@ public class Repository
                 SELECT run
                 FROM runs
                 WHERE id = $1
-                    AND status NOT IN ('Failed', 'Succeeded', 'Canceled')
+                    AND status NOT IN ('Failed', 'Succeeded', 'Canceled', 'Canceling')
                 FOR UPDATE
                 """, conn)
             {
@@ -550,7 +550,7 @@ public class Repository
                 await using var reader = await readRun.ExecuteReaderAsync(cancellationToken);
                 if (!await reader.ReadAsync(cancellationToken))
                 {
-                    // The run is already in a terminal state so we don't do anything
+                    // The run is already in a terminal or canceling state so we don't do anything
                     return;
                 }
 


### PR DESCRIPTION
Small changes around `tyger run cancel`:

1. Fix a race condition where it was possible for a `Canceling` state to be overwritten and therefore a cancel request to not suceed.
2. Ensure `tyger run exec` doesn't wait to read output buffers if the run is canceled.