### PR TITLE
Fix runs paging regression

### DIFF
--- a/server/ControlPlane/Database/Migrations/4.cs
+++ b/server/ControlPlane/Database/Migrations/4.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Tyger.ControlPlane.Database.Migrations;
+
+public class Migrator4 : Migrator
+{
+    public override async Task Apply(Npgsql.NpgsqlDataSource dataSource, ILogger logger, CancellationToken cancellationToken)
+    {
+        using (var cmd = dataSource.CreateCommand(
+            """
+            CREATE INDEX IF NOT EXISTS idx_runs_created_at_id_status
+            ON runs (created_at, id)
+            INCLUDE (status)
+            """))
+        {
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        using (var cmd = dataSource.CreateCommand(
+            """
+            DROP INDEX IF EXISTS idx_runs_created_at
+            """))
+        {
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+    }
+}

--- a/server/ControlPlane/Database/Migrations/DatabaseVersions.cs
+++ b/server/ControlPlane/Database/Migrations/DatabaseVersions.cs
@@ -27,6 +27,10 @@ public enum DatabaseVersion
     [Description("Making run management more scalable")]
     [MinimumSupportedVersion]
     RunScalability = 3,
+
+    [Migrator(typeof(Migrator4))]
+    [Description("Adjusting run indexes")]
+    AddRunsIndexForPaging = 4,
 }
 
 public sealed class DatabaseVersions : BackgroundService, IHealthCheck


### PR DESCRIPTION
Fixing a regression in run paging (introduced in #147) where the continuation token filter was not aligned with the order by clause, making it possible for rows to be skipped.