### PR TITLE
Fix Docker run finalization regression

### DIFF
--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -489,7 +489,7 @@ timeoutSeconds: 600`, getTestConnectivityImage(t))
 	runSpecPath := filepath.Join(tempDir, "runspec.yaml")
 	require.NoError(os.WriteFile(runSpecPath, []byte(runSpec), 0644))
 
-	execStdOut := NewTygerCmdBuilder("run", "exec", "--file", runSpecPath, "--log-level", "trace").
+	execStdOut := NewTygerCmdBuilder("run", "exec", "--file", runSpecPath, "--logs", "--log-level", "trace").
 		Stdin("0123").
 		RunSucceeds(t)
 

--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -157,6 +157,61 @@ func TestEndToEndWithAutomaticallyCreatedBuffers(t *testing.T) {
 	require.Equal("Hello: Bonjour", output)
 }
 
+func TestStatusAfterFinalization(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// create a codespec
+	const codespecName = "testcodespecwithbuffercreation"
+
+	runTygerSucceeds(t,
+		"codespec",
+		"create", codespecName,
+		"-i=input", "-o=output",
+		"--image", BasicImage,
+		"--command",
+		"--",
+		"sh", "-c",
+		`
+		set -euo pipefail
+		inp=$(cat "$INPUT_PIPE")
+		echo "${inp}: Bonjour" > "$OUTPUT_PIPE"
+		`,
+	)
+
+	// create run
+	runId := runTygerSucceeds(t, "run", "create", "--codespec", codespecName, "--timeout", "10m")
+
+	runJson := runTygerSucceeds(t, "run", "show", runId)
+
+	var run model.Run
+	require.NoError(json.Unmarshal([]byte(runJson), &run))
+
+	inputBufferId := run.Job.Buffers["input"]
+	outputBufferId := run.Job.Buffers["output"]
+
+	runCommandSucceeds(t, "sh", "-c", fmt.Sprintf(`echo "Hello" | tyger buffer write "%s"`, inputBufferId))
+
+	waitForRunSuccess(t, runId)
+
+	output := runCommandSucceeds(t, "sh", "-c", fmt.Sprintf(`tyger buffer read "%s"`, outputBufferId))
+
+	require.Equal("Hello: Bonjour", output)
+
+	// force logs to be archived
+	_, err := controlplane.InvokeRequest(context.Background(), http.MethodPost, "v1/runs/_sweep", nil, nil)
+	require.Nil(err)
+
+	// force finalization
+	_, err = controlplane.InvokeRequest(context.Background(), http.MethodPost, "v1/runs/_sweep", nil, nil)
+	require.Nil(err)
+
+	// get run
+	runJson = runTygerSucceeds(t, "run", "show", runId)
+	require.NoError(json.Unmarshal([]byte(runJson), &run))
+	require.Equal(model.Succeeded.String(), run.Status.String())
+}
+
 func TestEndToEndWithYamlSpecAndAutomaticallyCreatedBuffers(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/cli/integrationtest/migrations_test.go
+++ b/cli/integrationtest/migrations_test.go
@@ -166,7 +166,7 @@ func TestDockerOnlineMigrations(t *testing.T) {
 	require.NoError(t, err)
 
 	defer func() {
-		runCommandSucceeds(t, "sudo", tygerPath, "api", "uninstall", "-f", configPath, "--delete-data")
+		runCommandSucceeds(t, "sudo", tygerPath, "api", "uninstall", "-f", configPath, "--delete-data", "--preserve-run-containers")
 	}()
 
 	runCommandSucceeds(t, "sudo", tygerPath, "api", "install", "-f", configPath)
@@ -232,7 +232,7 @@ func TestDockerOfflineMigrations(t *testing.T) {
 	require.NoError(t, err)
 
 	defer func() {
-		runCommandSucceeds(t, "sudo", tygerPath, "api", "uninstall", "-f", previousConfigPath, "--delete-data")
+		runCommandSucceeds(t, "sudo", tygerPath, "api", "uninstall", "-f", previousConfigPath, "--delete-data", "--preserve-run-containers")
 	}()
 
 	runCommandSucceeds(t, "sudo", tygerPath, "api", "install", "-f", previousConfigPath)

--- a/cli/internal/cmd/install/api.go
+++ b/cli/internal/cmd/install/api.go
@@ -67,6 +67,7 @@ func newApiInstallCommand() *cobra.Command {
 func newApiUninstallCommand() *cobra.Command {
 	flags := commonFlags{}
 	deleteData := false
+	preserveRunContainers := false
 	cmd := cobra.Command{
 		Use:                   "uninstall -f CONFIG.yml",
 		Short:                 "Uninstall the Typer API",
@@ -78,7 +79,7 @@ func newApiUninstallCommand() *cobra.Command {
 
 			log.Info().Msg("Starting Tyger API uninstall")
 
-			if err := installer.UninstallTyger(ctx, deleteData); err != nil {
+			if err := installer.UninstallTyger(ctx, deleteData, preserveRunContainers); err != nil {
 				if !errors.Is(err, install.ErrAlreadyLoggedError) {
 					log.Fatal().Err(err).Send()
 				}
@@ -91,6 +92,8 @@ func newApiUninstallCommand() *cobra.Command {
 
 	addCommonFlags(&cmd, &flags)
 	cmd.Flags().BoolVar(&deleteData, "delete-data", deleteData, "Permanently delete data (Docker only)")
+	cmd.Flags().BoolVar(&preserveRunContainers, "preserve-run-containers", preserveRunContainers, "Preserve run containers (Docker only)") // for testing purposes only
+	cmd.Flags().MarkHidden("preserve-run-containers")
 	return &cmd
 }
 

--- a/cli/internal/install/cloudinstall/helm.go
+++ b/cli/internal/install/cloudinstall/helm.go
@@ -670,7 +670,7 @@ func GetChartSpec(
 	return chartSpec, nil
 }
 
-func (inst *Installer) UninstallTyger(ctx context.Context, _ bool) error {
+func (inst *Installer) UninstallTyger(ctx context.Context, _, _ bool) error {
 	restConfig, err := inst.GetUserRESTConfig(ctx)
 	if err != nil {
 		return err

--- a/cli/internal/install/cloudinstall/migrations.go
+++ b/cli/internal/install/cloudinstall/migrations.go
@@ -43,7 +43,7 @@ func runWithMinimalTygerInstallation[T any](ctx context.Context, inst *Installer
 		inst.Config.Api.Helm.Tyger.Values["onlyMigrationDependencies"] = false
 
 		defer func() {
-			inst.UninstallTyger(ctx, false)
+			inst.UninstallTyger(ctx, false, false)
 		}()
 	}
 

--- a/cli/internal/install/installer.go
+++ b/cli/internal/install/installer.go
@@ -38,7 +38,7 @@ type Installer interface {
 	QuickValidateConfig() bool
 
 	InstallTyger(ctx context.Context) error
-	UninstallTyger(ctx context.Context, deleteData bool) error
+	UninstallTyger(ctx context.Context, deleteData bool, preserveRunContainers bool) error
 
 	ListDatabaseVersions(ctx context.Context, all bool) ([]DatabaseVersion, error)
 	ApplyMigrations(ctx context.Context, targetVersion int, latest bool, offline bool, wait bool) error


### PR DESCRIPTION
Fixing a regression introduced in #147 when running in Docker,  where the finalization process would reset the status to `Pending`. This is because when running in Kubernetes, the database has the most current status when finalizing, but this is not the case with Docker. 