### PR TITLE
Ephemeral buffer hardening

### DIFF
--- a/cli/cmd/buffer-sidecar/main.go
+++ b/cli/cmd/buffer-sidecar/main.go
@@ -178,7 +178,7 @@ func newRootCommand() *cobra.Command {
 							log.Warn().Msg("OpenFile operation canceled.")
 							readerChan <- dataplane.ValueOrError[io.ReadCloser]{Err: fmt.Errorf("waiting for file canceled: %w", err)}
 							go func() {
-								// give some time for a client to connect and observe the empty reponse instead of just closing the listener
+								// give some time for a client to connect and observe the empty response instead of just closing the listener
 								time.Sleep(time.Minute)
 								cancel()
 							}()

--- a/cli/internal/dataplane/relayserver.go
+++ b/cli/internal/dataplane/relayserver.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	errorCodeHeaderName    = "x-ms-error-code"
-	errorMessageHeaderName = "x-ms-error-message"
+	errorCodeHeaderName = "x-ms-error-code"
 )
 
 const (
@@ -158,10 +157,16 @@ func RelayOutputServer(
 						w.Header().Set(errorCodeHeaderName, failedToOpenReaderErrorCode)
 						return
 					}
+
+					inputReader = valOrErr.Value
 				case <-ctx.Done():
 					w.Header().Set(errorCodeHeaderName, contextCancelledErrorCode)
 					return
 				}
+			}
+
+			if inputReader == nil {
+				panic("inputReader is nil")
 			}
 
 			defer inputReader.Close()

--- a/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
+++ b/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
@@ -208,7 +208,6 @@ public partial class DockerRunCreator : RunCreatorBase, IRunCreator, IHostedServ
                 // case of the relay server not having started vs exited.
                 File.Create(relaySocketPath).Close();
 
-
                 sidecarLabels = sidecarLabels.Add(EphemeralBufferSocketPathLabelKey, relaySocketPath);
 
                 args.AddRange([

--- a/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
+++ b/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
@@ -203,6 +203,12 @@ public partial class DockerRunCreator : RunCreatorBase, IRunCreator, IHostedServ
 
                 relaySocketPath = accessUri.AbsolutePath.Split(':')[0];
 
+                // Create a placeholder file for the relay socket. This is so that attempts to connect to the socket will return
+                // a connection refused error instead of a file not found error, so that the client can distinguish between the
+                // case of the relay server not having started vs exited.
+                File.Create(relaySocketPath).Close();
+
+
                 sidecarLabels = sidecarLabels.Add(EphemeralBufferSocketPathLabelKey, relaySocketPath);
 
                 args.AddRange([


### PR DESCRIPTION
1. Use HTTP trailers to signal an error to the client when an error occurs when reading the named pipe in the buffer sidecar
2. Return response headers as soon as possible from relay server to avoid client timeouts
3. Improve error messages for common error cases.