### PR TITLE
Support multiple storage accounts

### DIFF
--- a/Makefile.cloud
+++ b/Makefile.cloud
@@ -100,6 +100,7 @@ set-localsettings: set-context
 			},
 			"buffers": {
 				"cloudStorage": {
+					"defaultLocation": "$$(echo $${helm_values} | jq -r '.location')",
 					"storageAccounts": $$(echo $${helm_values} | jq -c '.buffers.storageAccounts')
 				},
 				"bufferSidecarImage": "$$(echo '${ENVIRONMENT_CONFIG_JSON}' | jq -r '.api.helm.tyger.values.bufferSidecarImage')",

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -24,7 +24,7 @@ set-localsettings: ensure-data-plane-cert
 
 	jq <<- EOF > ${CONTROL_PLANE_SERVER_PATH}/appsettings.local.json
 		{
-			"urls": "http://unix:$${install_path}/api.sock",
+			"urls": "http://unix:$${install_path}/control-plane/tyger.sock",
 			"logging": { "Console": {"FormatterName": "simple" } },
 			"auth": {
 				"enabled": "false"

--- a/cli/cmd/buffer-copier/main.go
+++ b/cli/cmd/buffer-copier/main.go
@@ -160,6 +160,12 @@ func createDatabaseConnectionPool(ctx context.Context, commonFlags *databaseFlag
 	return pool, nil
 }
 
+func getStorageAccountEndpointFromId(ctx context.Context, pool *pgxpool.Pool, storageAccountId int) (string, error) {
+	var sourceStorageEndpoint string
+	err := pool.QueryRow(ctx, `SELECT endpoint FROM storage_accounts WHERE id = $1`, storageAccountId).Scan(&sourceStorageEndpoint)
+	return sourceStorageEndpoint, err
+}
+
 type RoundripTransporter struct {
 	inner http.RoundTripper
 }

--- a/cli/integrationtest/expected_openapi_spec.yaml
+++ b/cli/integrationtest/expected_openapi_spec.yaml
@@ -148,6 +148,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
+  /v1/buffers/storage-accounts:
+    get:
+      tags:
+        - tyger-server
+      operationId: getStorageAccounts
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StorageAccount'
   /v1/buffers/export:
     post:
       tags:
@@ -498,6 +512,9 @@ components:
       properties:
         id:
           type: string
+        location:
+          type: string
+          nullable: true
         eTag:
           type: string
         createdAt:
@@ -654,6 +671,9 @@ components:
     ExportBuffersRequest:
       type: object
       properties:
+        sourceStorageAccountName:
+          type: string
+          nullable: true
         destinationStorageEndpoint:
           type: string
         filters:
@@ -664,6 +684,10 @@ components:
       additionalProperties: false
     ImportBuffersRequest:
       type: object
+      properties:
+        storageAccountName:
+          type: string
+          nullable: true
       additionalProperties: false
     JobCodespec:
       allOf:
@@ -837,6 +861,16 @@ components:
         outputBuffer:
           type: string
           nullable: true
+      additionalProperties: false
+    StorageAccount:
+      type: object
+      properties:
+        name:
+          type: string
+        location:
+          type: string
+        endpoint:
+          type: string
       additionalProperties: false
     WorkerCodespec:
       allOf:

--- a/cli/integrationtest/migrations_test.go
+++ b/cli/integrationtest/migrations_test.go
@@ -139,53 +139,55 @@ func getTempDockerInstallationPath(t *testing.T) string {
 	return installationPath
 }
 
-func TestDockerOnlineMigrations(t *testing.T) {
-	t.Parallel()
-	skipUnlessUsingUnixSocket(t)
-	skipIfNotUsingUnixSocketDirectly(t)
+// TODO: Re-enable this test when we have a current database version that supports online migrations
 
-	installationPath := getTempDockerInstallationPath(t)
-	defer os.RemoveAll(installationPath)
+// func TestDockerOnlineMigrations(t *testing.T) {
+// 	t.Parallel()
+// 	skipUnlessUsingUnixSocket(t)
+// 	skipIfNotUsingUnixSocketDirectly(t)
 
-	environmentConfig := runCommandSucceeds(t, "../../scripts/get-config.sh", "--docker")
+// 	installationPath := getTempDockerInstallationPath(t)
+// 	defer os.RemoveAll(installationPath)
 
-	lowercaseTestName := strings.ToLower(t.Name())
-	if len(lowercaseTestName) > 23 {
-		lowercaseTestName = lowercaseTestName[:23]
-	}
-	configMap := make(map[string]any)
-	require.NoError(t, yaml.Unmarshal([]byte(environmentConfig), &configMap))
-	configMap["environmentName"] = lowercaseTestName
-	configMap["installationPath"] = installationPath
-	configMap["initialDatabaseVersion"] = 3
-	p, err := dataplane.GetFreePort()
-	require.NoError(t, err)
-	configMap["dataPlanePort"] = p
-	configMap["network"] = map[string]any{"subnet": "172.255.0.0/24"}
+// 	environmentConfig := runCommandSucceeds(t, "../../scripts/get-config.sh", "--docker")
 
-	updatedEnvironmentConfigBytes, err := yaml.Marshal(configMap)
-	require.NoError(t, err)
+// 	lowercaseTestName := strings.ToLower(t.Name())
+// 	if len(lowercaseTestName) > 23 {
+// 		lowercaseTestName = lowercaseTestName[:23]
+// 	}
+// 	configMap := make(map[string]any)
+// 	require.NoError(t, yaml.Unmarshal([]byte(environmentConfig), &configMap))
+// 	configMap["environmentName"] = lowercaseTestName
+// 	configMap["installationPath"] = installationPath
+// 	configMap["initialDatabaseVersion"] = 3
+// 	p, err := dataplane.GetFreePort()
+// 	require.NoError(t, err)
+// 	configMap["dataPlanePort"] = p
+// 	configMap["network"] = map[string]any{"subnet": "172.255.0.0/24"}
 
-	tempDir := t.TempDir()
-	configPath := fmt.Sprintf("%s/environment-config.yaml", tempDir)
-	require.NoError(t, os.WriteFile(configPath, updatedEnvironmentConfigBytes, 0644))
+// 	updatedEnvironmentConfigBytes, err := yaml.Marshal(configMap)
+// 	require.NoError(t, err)
 
-	tygerPath, err := exec.LookPath("tyger")
-	require.NoError(t, err)
-	tygerPath, err = filepath.Abs(tygerPath)
-	require.NoError(t, err)
+// 	tempDir := t.TempDir()
+// 	configPath := fmt.Sprintf("%s/environment-config.yaml", tempDir)
+// 	require.NoError(t, os.WriteFile(configPath, updatedEnvironmentConfigBytes, 0644))
 
-	defer func() {
-		runCommandSucceeds(t, "sudo", tygerPath, "api", "uninstall", "-f", configPath, "--delete-data", "--preserve-run-containers")
-	}()
+// 	tygerPath, err := exec.LookPath("tyger")
+// 	require.NoError(t, err)
+// 	tygerPath, err = filepath.Abs(tygerPath)
+// 	require.NoError(t, err)
 
-	runCommandSucceeds(t, "sudo", tygerPath, "api", "install", "-f", configPath)
+// 	defer func() {
+// 		runCommandSucceeds(t, "sudo", tygerPath, "api", "uninstall", "-f", configPath, "--delete-data", "--preserve-run-containers")
+// 	}()
 
-	runTygerSucceeds(t, "api", "migrations", "apply", "--latest", "--offline", "--wait", "-f", configPath)
+// 	runCommandSucceeds(t, "sudo", tygerPath, "api", "install", "-f", configPath)
 
-	logs := runTygerSucceeds(t, "api", "migrations", "logs", "4", "-f", configPath)
-	assert.Contains(t, logs, "Migration 4 complete")
-}
+// 	runTygerSucceeds(t, "api", "migrations", "apply", "--latest", "--offline", "--wait", "-f", configPath)
+
+// 	logs := runTygerSucceeds(t, "api", "migrations", "logs", "4", "-f", configPath)
+// 	assert.Contains(t, logs, "Migration 4 complete")
+// }
 
 func TestDockerOfflineMigrations(t *testing.T) {
 	t.Parallel()

--- a/cli/internal/controlplane/model/model.go
+++ b/cli/internal/controlplane/model/model.go
@@ -24,6 +24,7 @@ type Buffer struct {
 	Id        string            `json:"id"`
 	ETag      string            `json:"etag"`
 	CreatedAt time.Time         `json:"createdAt"`
+	Location  string            `json:"location,omitempty"`
 	Tags      map[string]string `json:"tags,omitempty"`
 }
 
@@ -34,6 +35,12 @@ type BufferAccess struct {
 type BufferParameters struct {
 	Inputs  []string `json:"inputs,omitempty"`
 	Outputs []string `json:"outputs,omitempty"`
+}
+
+type StorageAccount struct {
+	Name     string `json:"name"`
+	Location string `json:"location"`
+	Endpoint string `json:"endpoint"`
 }
 
 type OvercommittableResources struct {
@@ -232,7 +239,12 @@ type Cluster struct {
 }
 
 type ExportBuffersRequest struct {
+	SourceStorageAccountName   string            `json:"sourceStorageAccountName"`
 	DestinationStorageEndpoint string            `json:"destinationStorageEndpoint"`
 	Filters                    map[string]string `json:"filters,omitempty"`
 	HashIds                    bool              `json:"hashIds,omitempty"`
+}
+
+type ImportBuffersRequest struct {
+	StorageAccountName string `json:"storageAccountName"`
 }

--- a/cli/internal/install/cloudinstall/helm.go
+++ b/cli/internal/install/cloudinstall/helm.go
@@ -426,7 +426,7 @@ func (inst *Installer) InstallTygerHelmChart(ctx context.Context, dryRun bool) (
 
 		accountValues := map[string]any{
 			"name":     accountConfig.Name,
-			"location": accountConfig.Location,
+			"location": *acc.Properties.PrimaryLocation,
 			"endpoint": *acc.Properties.PrimaryEndpoints.Blob,
 		}
 
@@ -464,6 +464,7 @@ func (inst *Installer) InstallTygerHelmChart(ctx context.Context, dryRun bool) (
 			"bufferCopierImage":  fmt.Sprintf("%s%sbuffer-copier:%s", install.ContainerRegistry, install.GetNormalizedContainerRegistryDirectory(), install.ContainerImageTag),
 			"workerWaiterImage":  fmt.Sprintf("%s%sworker-waiter:%s", install.ContainerRegistry, install.GetNormalizedContainerRegistryDirectory(), install.ContainerImageTag),
 			"hostname":           inst.Config.Api.DomainName,
+			"location":           inst.Config.Cloud.DefaultLocation,
 			"identity": map[string]any{
 				"tygerServer": map[string]any{
 					"name":     tygerServerIdentity.Name,

--- a/cli/internal/install/dockerinstall/migrations.go
+++ b/cli/internal/install/dockerinstall/migrations.go
@@ -296,6 +296,8 @@ func (inst *Installer) startMigrationRunner(ctx context.Context, containerName s
 				"Database__AutoMigrate=true",
 				"Database__TygerServerRoleName=tyger-server",
 				"Compute__Docker__Enabled=true",
+				fmt.Sprintf("Buffers__LocalStorage__DataPlaneEndpoint=http+unix://%s/data-plane/tyger.data.sock", inst.Config.InstallationPath),
+				fmt.Sprintf("Buffers__LocalStorage__TcpDataPlaneEndpoint=http://localhost:%d", inst.Config.DataPlanePort),
 			},
 			Cmd:    args,
 			Labels: labels,

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -45,6 +45,9 @@ cloud:
   storage:
     buffers:
       - name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}tygerbuf
+      - name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}tygerbuf2
+      - name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}tygerbuf3
+        location: ${TYGER_SECONDARY_LOCATION}
     logs:
       name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}tygerlog
 

--- a/deploy/helm/tyger/templates/migration-runner.yaml
+++ b/deploy/helm/tyger/templates/migration-runner.yaml
@@ -58,6 +58,10 @@ spec:
           env:
             - name: AZURE_CLIENT_ID
               value: {{ .Values.identity.migrationRunner.clientId }}
+            - name: Compute__Kubernetes__Namespace
+              value: {{ .Release.Namespace }}
+            - name: Compute__Kubernetes__JobServiceAccount
+              value: {{ include "tyger.fullname" . }}-job
             - name: Database__Host
               value: {{ .Values.database.host }}
             - name: Database__DatabaseName
@@ -70,10 +74,16 @@ spec:
               value: {{ .Values.identity.tygerServer.name }}
             - name: Database__TygerServerIdentity
               value: {{ .Values.identity.tygerServer.name }}
-            - name: Compute__Kubernetes__Namespace
-              value: {{ .Release.Namespace }}
-            - name: Compute__Kubernetes__JobServiceAccount
-              value: {{ include "tyger.fullname" . }}-job
+            - name: Buffers__CloudStorage__DefaultLocation
+              value: "{{ .Values.location }}"
+            {{- range $index, $element := .Values.buffers.storageAccounts }}
+            - name: Buffers__CloudStorage__StorageAccounts__{{ $index }}__name
+              value: "{{ $element.name }}"
+            - name: Buffers__CloudStorage__StorageAccounts__{{ $index }}__location
+              value: "{{ $element.location }}"
+            - name: Buffers__CloudStorage__StorageAccounts__{{ $index }}__endpoint
+              value: "{{ $element.endpoint }}"
+            {{- end }}
 
       serviceAccount: {{ .Values.identity.migrationRunner.name }}
       {{- with .Values.nodeSelector }}

--- a/deploy/helm/tyger/templates/server.yaml
+++ b/deploy/helm/tyger/templates/server.yaml
@@ -166,6 +166,8 @@ spec:
               value: {{ .Values.identity.tygerServer.name }}
             - name: Database__AutoMigrate
               value: "{{ .Values.database.autoMigrate }}"
+            - name: Buffers__CloudStorage__DefaultLocation
+              value: "{{ .Values.location }}"
             {{- range $index, $element := .Values.buffers.storageAccounts }}
             - name: Buffers__CloudStorage__StorageAccounts__{{ $index }}__name
               value: "{{ $element.name }}"

--- a/deploy/helm/tyger/values.yaml
+++ b/deploy/helm/tyger/values.yaml
@@ -6,6 +6,8 @@ replicaCount: 1
 image:
 imagePullPolicy: IfNotPresent
 
+location:
+
 identity:
   tygerServer:
     name:

--- a/docs/guides/buffers.md
+++ b/docs/guides/buffers.md
@@ -18,8 +18,26 @@ To create a buffer, run:
 tyger buffer create
 ```
 
+
 This command will output the new buffer's ID, which is used for operations like
 buffer reading, buffer writing, and creating runs.
+
+### Specifying the location of a buffer
+
+In a cloud installation, you can use multiple storage accounts for buffer
+storage. If those accounts are in different cloud locations (regions), you can
+specify the location that that you would like the buffer to be crated in with
+the `--location` parameter. The location is the lowercase name of the cloud
+location with spaces removed, such as `eastus` or `westus2`. If multiple storage
+accounts are in the same location, accounts are selected in a round-robin
+fashion.
+
+The available regions for a tyger installation can fetched with:
+
+```bash
+tyger buffer storage-account list
+```
+
 
 ## Writing to a buffer
 
@@ -101,6 +119,7 @@ The response looks like:
   "id": "yf4sx2aqzitepjhmxjhanomn5e",
   "etag": "638418036499348393",
   "createdAt": "2024-01-25T18:20:49.951262Z",
+  "location": "eastus",
   "tags": {
     "mykey1": "myvalue1",
     "mykey2": "myvalue2"
@@ -119,6 +138,7 @@ tyger buffer set $buffer_id --tag myKey1=myvalue1Updated --tag mykey3=myvalue3
   "id": "yf4sx2aqzitepjhmxjhanomn5e",
   "etag": "638418039170119977",
   "createdAt": "2024-01-25T18:20:49.951262Z",
+  "location": "eastus",
   "tags": {
     "myKey1": "myvalue1Updated",
     "mykey2": "myvalue2",
@@ -138,6 +158,7 @@ tyger buffer set $buffer_id --clear-tags --tag myKey1=yetAnotherValue
   "id": "yf4sx2aqzitepjhmxjhanomn5e",
   "etag": "638418039170119988",
   "createdAt": "2024-01-25T18:20:49.951262Z",
+  "location": "eastus",
   "tags": {
     "myKey1": "yetAnotherValue",
   }
@@ -171,6 +192,7 @@ tyger buffer list --tag mykey1=myvalue1
     "id": "yf4sx2aqzitepjhmxjhanomn5e",
     "etag": "638418036499348393",
     "createdAt": "2024-01-25T18:20:49.951262Z",
+    "location": "eastus",
     "tags": {
       "mykey1": "myvalue1",
       "mykey2": "myvalue2"
@@ -191,6 +213,7 @@ tyger buffer list --tag mykey1=myvalue1 --tag mykey2=myvalue2
     "id": "yf4sx2aqzitepjhmxjhanomn5e",
     "etag": "638418036499348393",
     "createdAt": "2024-01-25T18:20:49.951262Z",
+    "location": "eastus",
     "tags": {
       "mykey1": "myvalue1",
       "mykey2": "myvalue2"
@@ -218,12 +241,18 @@ their tags from one instance to another. This can be accomplished in two steps.
 ### Export the buffers
 
 ```bash
-tyger buffer export DESTINATION_STORAGE_ENDPOINT [--tag KEY=VALUE ...]
+tyger buffer export DESTINATION_STORAGE_ENDPOINT [--source-storage-account SOURCE_ACCOUNT_NAME] [--tag KEY=VALUE ...]
 ```
 
 `DESTINATION_STORAGE_ENDPOINT` should be the blob endpoint of the destination
 Tyger instance's storage account. The Tyger server's managed identity needs to have
 `Storage Blob Data Contributor` access on this storage account.
+
+
+If multiple storage accounts are configured for the source Tyger installation
+`--source-storage-account` must be provided. The export command will only export
+from a single storage account. The available storage accounts can be listed with
+the command `tyger buffer storage-account list`.
 
 To only export a subset of buffer, you can filter the buffers to be exported by
 tags.
@@ -236,9 +265,14 @@ Once the export run has completed successfully, you can import these buffers
 into the destination Tyger instance's database with the command:
 
 ```bash
-tyger buffer import
+tyger buffer import [--storage-account STORAGE_ACCOUNT_NAME]
 ```
 
 This starts a run that scans though the instance's storage account and imports
 new buffers. Note that existing buffers are not touched and their tags will not
 be updated.
+
+If multiple storage accounts are configured for the Tyger installation
+`--storage-account` must be provided. The import command will only import from a
+from a single storage account. The available storage accounts can be listed with
+the command `tyger buffer storage-account list`.

--- a/scripts/get-config.sh
+++ b/scripts/get-config.sh
@@ -104,10 +104,14 @@ else
       export TYGER_SYSTEM_NODE_SKU="${TYGER_SYSTEM_NODE_SKU:-Standard_e2s_v3}"
       export TYGER_CPU_NODE_SKU="${TYGER_CPU_NODE_SKU:-Standard_E8s_v3}"
       export TYGER_GPU_NODE_SKU="${TYGER_GPU_NODE_SKU:-Standard_NC6s_v3}"
+
+      export TYGER_SECONDARY_LOCATION="${TYGER_SECONDARY_LOCATION:-westus2}"
     else
       export TYGER_SYSTEM_NODE_SKU="${TYGER_SYSTEM_NODE_SKU:-Standard_DS2_v2}"
       export TYGER_CPU_NODE_SKU="${TYGER_CPU_NODE_SKU:-Standard_DS12_v2}"
       export TYGER_GPU_NODE_SKU="${TYGER_GPU_NODE_SKU:-Standard_NC6s_v3}"
+
+      export TYGER_SECONDARY_LOCATION="${TYGER_SECONDARY_LOCATION:-eastus}"
     fi
 
   fi

--- a/server/ControlPlane/Buffers/Buffers.cs
+++ b/server/ControlPlane/Buffers/Buffers.cs
@@ -47,6 +47,7 @@ public static class Buffers
                 {
                     builder.Services.AddSingleton<LocalStorageBufferProvider>();
                     builder.Services.AddSingleton<IBufferProvider>(sp => sp.GetRequiredService<LocalStorageBufferProvider>());
+                    builder.Services.AddHostedService(sp => sp.GetRequiredService<LocalStorageBufferProvider>());
                     builder.Services.AddHealthChecks().AddCheck<LocalStorageBufferProvider>("data plane");
                 }
 

--- a/server/ControlPlane/Buffers/IBufferProvider.cs
+++ b/server/ControlPlane/Buffers/IBufferProvider.cs
@@ -2,18 +2,19 @@
 // Licensed under the MIT License.
 
 using Tyger.ControlPlane.Model;
+using Buffer = Tyger.ControlPlane.Model.Buffer;
 
 namespace Tyger.ControlPlane.Buffers;
 
 public interface IBufferProvider
 {
-    Task CreateBuffer(string id, CancellationToken cancellationToken);
-    Task<bool> BufferExists(string id, CancellationToken cancellationToken);
+    Task<Buffer> CreateBuffer(Buffer buffer, CancellationToken cancellationToken);
 
-    Uri CreateBufferAccessUrl(string id, bool writeable, bool preferTcp);
+    Task<IList<(string id, bool writeable, BufferAccess? bufferAccess)>> CreateBufferAccessUrls(IList<(string id, bool writeable)> requests, bool preferTcp, bool checkExists, CancellationToken cancellationToken);
+    IList<StorageAccount> GetStorageAccounts();
 
     Task<Run> ExportBuffers(ExportBuffersRequest exportBufferRequest, CancellationToken cancellationToken);
-    Task<Run> ImportBuffers(CancellationToken cancellationToken);
+    Task<Run> ImportBuffers(ImportBuffersRequest importBuffersRequest, CancellationToken cancellationToken);
 }
 
 public interface IEphemeralBufferProvider

--- a/server/ControlPlane/Database/Migrations/5.cs
+++ b/server/ControlPlane/Database/Migrations/5.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Options;
+using NpgsqlTypes;
+using Tyger.ControlPlane.Buffers;
+
+namespace Tyger.ControlPlane.Database.Migrations;
+
+public class Migrator5 : Migrator
+{
+    private readonly CloudBufferStorageOptions _cloudBufferStorageOptions;
+
+    public Migrator5(IOptions<CloudBufferStorageOptions> cloudBufferStorageOptions)
+    {
+        _cloudBufferStorageOptions = cloudBufferStorageOptions.Value;
+    }
+
+    public override async Task Apply(Npgsql.NpgsqlDataSource dataSource, ILogger logger, CancellationToken cancellationToken)
+    {
+        await using (var batch = dataSource.CreateBatch())
+        {
+            batch.BatchCommands.Add(new(
+                $"""
+                CREATE TABLE IF NOT EXISTS storage_accounts (
+                    id int NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY (MINVALUE 0 START WITH 0 INCREMENT BY 1),
+                    name text NOT NULL,
+                    location text,
+                    endpoint text
+                )
+                """));
+
+            batch.BatchCommands.Add(new(
+                $"""
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_storage_accounts_name
+                ON storage_accounts (name)
+                """));
+
+            await batch.ExecuteNonQueryAsync(cancellationToken);
+
+        }
+
+        bool hasStorageAccounts;
+        using (var anyStorageAccountsCmd = dataSource.CreateCommand(
+            """
+            SELECT 1 FROM storage_accounts LIMIT 1
+            """))
+        {
+            hasStorageAccounts = await anyStorageAccountsCmd.ExecuteScalarAsync(cancellationToken) != null;
+        }
+
+        var defaultStorageAccountId = 0;
+        if (!hasStorageAccounts)
+        {
+            bool hasBuffers;
+            using (var anyBuffersCmd = dataSource.CreateCommand(
+                """
+                SELECT 1 FROM buffers LIMIT 1
+                """))
+            {
+                hasBuffers = await anyBuffersCmd.ExecuteScalarAsync(cancellationToken) != null;
+            }
+
+            if (hasBuffers)
+            {
+                string name;
+                string location;
+                if (_cloudBufferStorageOptions.StorageAccounts.Count > 0) // if running in the cloud, this is validated to be non-empty
+                {
+                    name = _cloudBufferStorageOptions.StorageAccounts[0].Name;
+                    location = _cloudBufferStorageOptions.StorageAccounts[0].Location;
+                }
+                else
+                {
+                    name = LocalStorageBufferProvider.AccountName;
+                    location = LocalStorageBufferProvider.AccountLocation;
+                }
+
+                await using var insertStorageAccountCmd = dataSource.CreateCommand(
+                    """
+                    INSERT INTO storage_accounts
+                    (name, location)
+                    VALUES ($1, $2)
+                    RETURNING id
+                    """);
+                insertStorageAccountCmd.Parameters.Add(new() { Value = name.ToLowerInvariant(), NpgsqlDbType = NpgsqlDbType.Text });
+                insertStorageAccountCmd.Parameters.Add(new() { Value = location.ToLowerInvariant(), NpgsqlDbType = NpgsqlDbType.Text });
+
+                defaultStorageAccountId = (int)(await insertStorageAccountCmd.ExecuteScalarAsync(cancellationToken))!;
+            }
+        }
+
+        await using var addStorageAccountIdColumnCmd = dataSource.CreateCommand(
+            $"""
+            ALTER TABLE buffers
+            ADD COLUMN IF NOT EXISTS storage_account_id int REFERENCES storage_accounts(id) DEFAULT {defaultStorageAccountId}
+            """);
+
+        await addStorageAccountIdColumnCmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+}

--- a/server/ControlPlane/Database/Migrations/DatabaseVersions.cs
+++ b/server/ControlPlane/Database/Migrations/DatabaseVersions.cs
@@ -25,12 +25,16 @@ public enum DatabaseVersion
 
     [Migrator(typeof(Migrator3))]
     [Description("Making run management more scalable")]
-    [MinimumSupportedVersion]
     RunScalability = 3,
 
     [Migrator(typeof(Migrator4))]
     [Description("Adjusting run indexes")]
     AddRunsIndexForPaging = 4,
+
+    [Migrator(typeof(Migrator5))]
+    [Description("Support multiple storage accounts")]
+    [MinimumSupportedVersion]
+    MultipleStorageAccounts = 5,
 }
 
 public sealed class DatabaseVersions : BackgroundService, IHealthCheck

--- a/server/ControlPlane/Model/Model.cs
+++ b/server/ControlPlane/Model/Model.cs
@@ -36,6 +36,8 @@ public record Buffer : ModelBase
 {
     public string Id { get; init; } = "";
 
+    public string? Location { get; init; }
+
     public string ETag { get; init; } = "";
 
     public DateTimeOffset CreatedAt { get; init; }
@@ -46,6 +48,8 @@ public record Buffer : ModelBase
 public record BufferAccess(Uri Uri) : ModelBase;
 
 public record ServiceMetadata(string? Authority = null, string? Audience = null, string? CliAppUri = null, IEnumerable<string>? Capabilities = null) : ModelBase;
+
+public record StorageAccount(string Name, string Location, string Endpoint) : ModelBase;
 
 [Equatable]
 public partial record BufferParameters(
@@ -509,9 +513,9 @@ public record Cluster(string Name, string Location, IReadOnlyList<NodePool> Node
 
 public record NodePool(string Name, string VmSize);
 
-public record ExportBuffersRequest(string DestinationStorageEndpoint, Dictionary<string, string>? Filters, [property: OpenApiExclude] bool HashIds) : ModelBase;
+public record ExportBuffersRequest(string? SourceStorageAccountName, string DestinationStorageEndpoint, Dictionary<string, string>? Filters, [property: OpenApiExclude] bool HashIds) : ModelBase;
 
-public record ImportBuffersRequest() : ModelBase;
+public record ImportBuffersRequest(string? StorageAccountName) : ModelBase;
 
 [AttributeUsage(AttributeTargets.Property)]
 public class OpenApiExcludeAttribute : Attribute

--- a/server/ControlPlane/Program.cs
+++ b/server/ControlPlane/Program.cs
@@ -38,6 +38,7 @@ void AddCommonServices(IHostApplicationBuilder builder)
     builder.AddConfigurationSources();
     builder.AddDatabase();
     builder.AddCompute();
+    builder.AddBuffers();
     builder.ConfigureLogging();
     builder.AddManagedIdentity();
     builder.AddJsonFormatting();
@@ -50,7 +51,6 @@ void RunServer()
     AddCommonServices(builder);
     builder.AddLogArchive();
     builder.AddAuth();
-    builder.AddBuffers();
     builder.AddRuns();
     builder.AddOpenApi();
     builder.ConfigureUnixDomainSockets();


### PR DESCRIPTION
Adding support for multiple storage accounts for buffers in cloud deployments. Buffers can now be created specifying a location, e.g. `tyger buffer create --location eastus`.