### PR TITLE
Fix HTTP proxy logging

### DIFF
--- a/cli/internal/client/commandtransport.go
+++ b/cli/internal/client/commandtransport.go
@@ -94,6 +94,12 @@ func (c *CommandTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	return resp, nil
 }
 
+func (c *CommandTransport) GetUnderlyingTransport() *http.Transport {
+	return getHttpTransport(c.next)
+}
+
+var _ HttpTransportExposer = &CommandTransport{}
+
 type cleanupOnCloseReader struct {
 	io.ReadCloser
 	cleanup func()

--- a/cli/internal/client/unixtransport.go
+++ b/cli/internal/client/unixtransport.go
@@ -35,46 +35,58 @@ func makeUnixDialer(next dialContextFunc) dialContextFunc {
 	}
 }
 
-func makeUnixTransport(next http.RoundTripper) http.RoundTripper {
-	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.URL == nil {
-			return next.RoundTrip(req)
-		}
-
-		var scheme string
-		switch req.URL.Scheme {
-		case "http+unix":
-			scheme = "http"
-		case "https+unix":
-			scheme = "https"
-		default:
-			return next.RoundTrip(req)
-		}
-
-		parts := strings.SplitN(req.URL.Path, ":", 2)
-		var socketPath string
-		var requestPath string
-
-		switch len(parts) {
-		case 1:
-			socketPath = parts[0]
-			requestPath = ""
-		case 2:
-			socketPath = parts[0]
-			requestPath = parts[1]
-		default:
-			return nil, errors.New("unix transport: invalid path")
-		}
-
-		req = req.Clone(req.Context())
-
-		req.URL.Scheme = scheme
-		req.URL.Host = encodeUnixPathToHost(socketPath)
-		req.URL.Path = requestPath
-
-		return next.RoundTrip(req)
-	})
+type unixAwareTransport struct {
+	next http.RoundTripper
 }
+
+func makeUnixAwareTransport(next http.RoundTripper) http.RoundTripper {
+	return &unixAwareTransport{next: next}
+}
+
+func (t *unixAwareTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL == nil {
+		return t.next.RoundTrip(req)
+	}
+
+	var scheme string
+	switch req.URL.Scheme {
+	case "http+unix":
+		scheme = "http"
+	case "https+unix":
+		scheme = "https"
+	default:
+		return t.next.RoundTrip(req)
+	}
+
+	parts := strings.SplitN(req.URL.Path, ":", 2)
+	var socketPath string
+	var requestPath string
+
+	switch len(parts) {
+	case 1:
+		socketPath = parts[0]
+		requestPath = ""
+	case 2:
+		socketPath = parts[0]
+		requestPath = parts[1]
+	default:
+		return nil, errors.New("unix transport: invalid path")
+	}
+
+	req = req.Clone(req.Context())
+
+	req.URL.Scheme = scheme
+	req.URL.Host = encodeUnixPathToHost(socketPath)
+	req.URL.Path = requestPath
+
+	return t.next.RoundTrip(req)
+}
+
+func (t *unixAwareTransport) GetUnderlyingTransport() *http.Transport {
+	return getHttpTransport(t.next)
+}
+
+var _ HttpTransportExposer = &unixAwareTransport{}
 
 func encodeUnixPathToHost(socketPath string) string {
 	return fmt.Sprintf("!unix!%s", encoding.EncodeToString([]byte(socketPath)))


### PR DESCRIPTION
When using an HTTP proxy and `--log-level trace`, the `proxy` entry in the logs was empty even when a proxy was being used.