### PR TITLE
Improve multiple replica support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -51,26 +51,26 @@ RUN umask 0002 \
     && VERSION=20.11.0 bash install.sh \
     # DOCKER
     && cd /opt/features/src/docker-outside-of-docker \
-    && MOBY=false VERSION=24.0.6 DOCKERDASHCOMPOSEVERSION=none bash install.sh \
+    && MOBY=false VERSION=27.5.1 DOCKERDASHCOMPOSEVERSION=none bash install.sh \
     # AZURE CLI
     && cd /opt/features/src/azure-cli \
-    && VERSION=2.61.0 bash install.sh \
+    && VERSION=2.68.0 bash install.sh \
     # POWERSHELL
     && cd /opt/features/src/powershell \
     && VERSION=7.3.9 bash install.sh \
     # KUBECTL
     && cd /opt/features/src/kubectl-helm-minikube \
-    && VERSION=1.28.3 HELM=3.13.1 MINIKUBE=none bash install.sh \
+    && VERSION=1.31.5 HELM=3.16.4 MINIKUBE=none bash install.sh \
     # DOTNET
     && cd /opt/features/src/dotnet \
-    && VERSION=9.0.100 bash install.sh \
+    && VERSION=9.0.102 bash install.sh \
     # GO
     && cd /opt/features/src/go \
     && VERSION=1.23.1 bash install.sh \
     && chown -R "${USERNAME}" "${GOROOT}" "${GOPATH}" \
     # GitHub CLI
     && cd /opt/features/src/github-cli/ \
-    && VERSION=2.42.0 bash install.sh \
+    && VERSION=2.66.1 bash install.sh \
     # cleanup
     && rm -rf /opt/features
 

--- a/Makefile.cloud
+++ b/Makefile.cloud
@@ -210,3 +210,9 @@ variant-test:
 
 get-last-server-exception: set-context
 	(kubectl logs -l component=tyger-server | grep Exception || true) | tac | head -n 1 | jq -r '.exception'
+
+get-server-logs:
+	kubectl logs deployments/tyger-server --all-pods
+
+follow-server-logs:
+	kubectl logs deployments/tyger-server --all-pods --follow

--- a/deploy/helm/tyger/templates/server.yaml
+++ b/deploy/helm/tyger/templates/server.yaml
@@ -85,7 +85,7 @@ spec:
   selector:
     matchLabels:
       component: {{ $tygerName }}-server
-  replicas: {{ .Values.replicas }}
+  replicas: {{ .Values.replicaCount }}
   strategy:
     type: Recreate # For inner-loop local development. TODO: parameterize
   template:
@@ -95,6 +95,13 @@ spec:
         tyger-helm-revision: "{{ .Release.Revision }}"
         azure.workload.identity/use: "true"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  component: {{ $tygerName }}-server
+              topologyKey: "kubernetes.io/hostname"
       containers:
         - name: tyger
           image: {{ required "A value for image is required" .Values.image }}

--- a/server/Common/Middleware/RequestLogging.cs
+++ b/server/Common/Middleware/RequestLogging.cs
@@ -81,14 +81,16 @@ public class RequestLogging
         }
 
         var start = Stopwatch.GetTimestamp();
+        bool hasException = true;
         try
         {
             await _next(context);
+            hasException = false;
         }
         finally
         {
             var end = Stopwatch.GetTimestamp();
-            if (context.Request.Path != "/healthcheck" || context.Response.StatusCode != 200)
+            if (context.Request.Path != "/healthcheck" || hasException || context.Response.StatusCode is < 200 or >= 400)
             {
                 _logger.RequestCompleted(
                     SanitizeUserInputForLogging(context.Request.Method),

--- a/server/ControlPlane/Buffers/Buffers.cs
+++ b/server/ControlPlane/Buffers/Buffers.cs
@@ -35,7 +35,6 @@ public static class Buffers
                 {
                     builder.Services.AddSingleton<AzureBlobBufferProvider>();
                     builder.Services.AddSingleton<IBufferProvider>(sp => sp.GetRequiredService<AzureBlobBufferProvider>());
-                    builder.Services.AddHostedService(sp => sp.GetRequiredService<AzureBlobBufferProvider>());
                     builder.Services.Insert(0, ServiceDescriptor.Singleton<IHostedService>(sp => sp.GetRequiredService<AzureBlobBufferProvider>())); // Other startup services depend on this, so we add it early.
                     builder.Services.AddHealthChecks().AddCheck<AzureBlobBufferProvider>("buffers");
                 }

--- a/server/ControlPlane/Compute/Kubernetes/Kubernetes.cs
+++ b/server/ControlPlane/Compute/Kubernetes/Kubernetes.cs
@@ -49,6 +49,10 @@ public static class Kubernetes
         if (builder is WebApplicationBuilder)
         {
             builder.Services.AddOptions<KubernetesApiOptions>().BindConfiguration("compute:kubernetes").ValidateDataAnnotations().ValidateOnStart();
+
+            builder.Services.AddSingleton(sp => new LeaseManager(sp.GetRequiredService<Repository>(), "tyger-server-leader"));
+            builder.Services.Insert(0, ServiceDescriptor.Singleton<IHostedService>(sp => sp.GetRequiredService<LeaseManager>())); // Other startup services depend on this, so we add it early.
+
             builder.Services.AddSingleton<KubernetesRunCreator>();
             builder.Services.AddSingleton<IRunCreator>(sp => sp.GetRequiredService<KubernetesRunCreator>());
             builder.Services.AddHostedService(sp => sp.GetRequiredService<KubernetesRunCreator>());

--- a/server/ControlPlane/Compute/Kubernetes/LeaseManager.cs
+++ b/server/ControlPlane/Compute/Kubernetes/LeaseManager.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Threading.Channels;
 using Tyger.ControlPlane.Database;
 

--- a/server/ControlPlane/Compute/Kubernetes/LeaseManager.cs
+++ b/server/ControlPlane/Compute/Kubernetes/LeaseManager.cs
@@ -1,0 +1,54 @@
+using System.Threading.Channels;
+using Tyger.ControlPlane.Database;
+
+namespace Tyger.ControlPlane.Compute.Kubernetes;
+
+public class LeaseManager : BackgroundService
+{
+    private readonly Repository _repository;
+    private readonly string _leaseHolderId = Environment.MachineName;
+    private int _latestLeaseToken;
+
+    private int _started;
+    private readonly List<ChannelWriter<(bool, int)>> _onLeaseOwnershipAcquiredChannel = [];
+
+    public string LeaseName { get; }
+
+    public LeaseManager(Repository repository, string leaseName)
+    {
+        _repository = repository;
+        LeaseName = leaseName;
+    }
+
+    public void RegisterListener(ChannelWriter<(bool acquired, int token)> listener)
+    {
+        if (Volatile.Read(ref _started) == 1)
+        {
+            throw new InvalidOperationException($"Registering listeners after starting the lease is not supported.");
+        }
+
+        _onLeaseOwnershipAcquiredChannel.Add(listener);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (Interlocked.Exchange(ref _started, 1) == 1)
+        {
+            throw new InvalidOperationException("Lease can only be started once.");
+        }
+
+        await _repository.AcquireAndHoldLease(LeaseName, _leaseHolderId, async hasLease =>
+        {
+            var incrementedLeaseToken = Interlocked.Increment(ref _latestLeaseToken);
+            foreach (var listener in _onLeaseOwnershipAcquiredChannel)
+            {
+                await listener.WriteAsync((hasLease, incrementedLeaseToken), stoppingToken);
+            }
+        }, stoppingToken);
+    }
+
+    public int GetCurrentLeaseToken()
+    {
+        return Volatile.Read(ref _latestLeaseToken);
+    }
+}

--- a/server/ControlPlane/Database/Database.cs
+++ b/server/ControlPlane/Database/Database.cs
@@ -61,7 +61,6 @@ public static class Database
             }
 
             dataSourceBuilder.ConnectionStringBuilder.Username = databaseOptions.Username;
-            dataSourceBuilder.ConnectionStringBuilder.MaxPoolSize = 250;
             dataSourceBuilder.ConnectionStringBuilder.CheckCertificateRevocation = true;
 
             if (string.IsNullOrEmpty(databaseOptions.PasswordFile))

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0.100-azurelinux3.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0.102-azurelinux3.0 AS build
 ARG TARGETARCH
 
 WORKDIR /cp
@@ -42,9 +42,9 @@ RUN dotnet publish --no-restore --arch ${TARGETARCH} -c release -o /control-plan
 WORKDIR /src/server/DataPlane
 RUN dotnet publish --no-restore --arch ${TARGETARCH} -c release -o /data-plane
 
-FROM mcr.microsoft.com/dotnet/aspnet:9.0.0-azurelinux3.0 AS runtime-prep
+FROM mcr.microsoft.com/dotnet/aspnet:9.0.1-azurelinux3.0 AS runtime-prep
 
-FROM mcr.microsoft.com/dotnet/aspnet:9.0.0-azurelinux3.0-distroless AS control-plane
+FROM mcr.microsoft.com/dotnet/aspnet:9.0.1-azurelinux3.0-distroless AS control-plane
 COPY --from=build /cp /app
 WORKDIR /app/bin
 COPY --from=runtime-prep /usr/bin/sleep .
@@ -53,7 +53,7 @@ COPY --from=build /control-plane .
 USER app:app
 ENTRYPOINT ["/app/bin/tyger-server"]
 
-FROM mcr.microsoft.com/dotnet/aspnet:9.0.0-azurelinux3.0-distroless AS data-plane
+FROM mcr.microsoft.com/dotnet/aspnet:9.0.1-azurelinux3.0-distroless AS data-plane
 COPY --from=build /dp /app
 WORKDIR /app/bin
 COPY --from=build /static/curl .


### PR DESCRIPTION
Earlier tyger-server support for multiple instances ensured that data in the database would not be corrupted. But there was still a lot of duplicate work occurring as each instance would attempt to create and finalize all run objects. This leads to unnecessary load on the Kubernetes API.

In this change, only the elected leader will perform these operations.

I don't yet have tests that ensures the behavior is correct, so it will remain an unsupported feature. You need to set the replica count via Helm values directly.