### PR TITLE
Fail run when container image cannot be pulled

### DIFF
--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -483,6 +483,31 @@ timeoutSeconds: 600`, getTestConnectivityImage(t))
 	require.Equal("1234", execStdOut)
 }
 
+func TestInvalidImage(t *testing.T) {
+	t.Parallel()
+	skipIfUsingUnixSocket(t)
+
+	require := require.New(t)
+
+	missingImage := BasicImage + "thisisamissingtag"
+
+	runSpec := fmt.Sprintf(`
+job:
+  codespec:
+    image: %s
+tags:
+  testName: TestInvalidImage
+timeoutSeconds: 600`, missingImage)
+
+	tempDir := t.TempDir()
+	runSpecPath := filepath.Join(tempDir, "runspec.yaml")
+	require.NoError(os.WriteFile(runSpecPath, []byte(runSpec), 0644))
+
+	_, stdErr, err := runTyger("run", "exec", "--file", runSpecPath)
+	require.Error(err)
+	require.Contains(stdErr, fmt.Sprintf("%s: not found", missingImage))
+}
+
 func TestCodespecBufferTagsWithYamlSpec(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)


### PR DESCRIPTION
When a container image cannot be pulled, Kubernetes puts keeps the pod in a `Pending` state and keeps retrying to pull. This resulted in Tyger runs also remaining in a `Pending` state until they timed out. We now fail the run immediately.

Resolves #168 