### PR TITLE
Remove Swagger UI

### DIFF
--- a/server/ControlPlane/OpenApi/OpenApi.cs
+++ b/server/ControlPlane/OpenApi/OpenApi.cs
@@ -72,7 +72,6 @@ public static class OpenApi
     public static void UseOpenApi(this WebApplication app)
     {
         app.UseSwagger();
-        app.UseSwaggerUI();
     }
 }
 


### PR DESCRIPTION
For security reasons, we are no longer allowed to enable Swagger UI, which we weren't using anyway.