### PR TITLE
Fix a regression in IHostedService startup order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ az-login-from-host:
 	scripts/az-login-from-host.sh
 
 build-csharp:
-	find . -name *csproj | xargs -L 1 dotnet build
+	dotnet build server/tyger.sln
 
 build-go:
 	cd cli

--- a/server/Common/DependencyInjection/ServiceOrder.cs
+++ b/server/Common/DependencyInjection/ServiceOrder.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Tyger.Common.DependencyInjection;
+
+public static class ServiceOrderHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds a service descriptor to the IHostApplicationBuilder with a specified priority.
+    /// </summary>
+    /// <remarks>
+    /// If a service descriptor with the same service type already exists, the new service descriptor
+    /// will be inserted before the existing one if the new service's priority is higher. Otherwise, it will be added
+    /// to the end of the service collection. Services added outside of this method have priority 0.
+    /// </remarks>
+    public static IHostApplicationBuilder AddServiceWithPriority(this IHostApplicationBuilder builder, ServiceDescriptor serviceDescriptor, int priority)
+    {
+        builder.Properties[serviceDescriptor] = priority;
+        for (int i = 0; i < builder.Services.Count; i++)
+        {
+            var existingService = builder.Services[i];
+            if (existingService.ServiceType == serviceDescriptor.ServiceType)
+            {
+                var existingPriority = builder.Properties.TryGetValue(existingService, out var value) ? (int)value : 0;
+                if (priority > existingPriority)
+                {
+                    builder.Services.Insert(i, serviceDescriptor);
+                    return builder;
+                }
+            }
+        }
+
+        builder.Services.Add(serviceDescriptor);
+        return builder;
+    }
+}

--- a/server/ControlPlane/Buffers/Buffers.cs
+++ b/server/ControlPlane/Buffers/Buffers.cs
@@ -36,7 +36,7 @@ public static class Buffers
                 {
                     builder.Services.AddSingleton<AzureBlobBufferProvider>();
                     builder.Services.AddSingleton<IBufferProvider>(sp => sp.GetRequiredService<AzureBlobBufferProvider>());
-                    builder.AddServiceWithPriority(ServiceDescriptor.Singleton<IHostedService>(sp => sp.GetRequiredService<AzureBlobBufferProvider>()), 10); // Other startup services depend on this, so we add it early.
+                    builder.AddServiceWithPriority(ServiceDescriptor.Singleton<IHostedService>(sp => sp.GetRequiredService<AzureBlobBufferProvider>()), 10);
                     builder.Services.AddHealthChecks().AddCheck<AzureBlobBufferProvider>("buffers");
                 }
 

--- a/server/ControlPlane/Buffers/Buffers.cs
+++ b/server/ControlPlane/Buffers/Buffers.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
 using Microsoft.OpenApi.Models;
 using Tyger.Common.Api;
+using Tyger.Common.DependencyInjection;
 using Tyger.ControlPlane.Json;
 using Tyger.ControlPlane.Model;
 using Buffer = Tyger.ControlPlane.Model.Buffer;
@@ -35,7 +36,7 @@ public static class Buffers
                 {
                     builder.Services.AddSingleton<AzureBlobBufferProvider>();
                     builder.Services.AddSingleton<IBufferProvider>(sp => sp.GetRequiredService<AzureBlobBufferProvider>());
-                    builder.Services.Insert(0, ServiceDescriptor.Singleton<IHostedService>(sp => sp.GetRequiredService<AzureBlobBufferProvider>())); // Other startup services depend on this, so we add it early.
+                    builder.AddServiceWithPriority(ServiceDescriptor.Singleton<IHostedService>(sp => sp.GetRequiredService<AzureBlobBufferProvider>()), 10); // Other startup services depend on this, so we add it early.
                     builder.Services.AddHealthChecks().AddCheck<AzureBlobBufferProvider>("buffers");
                 }
 

--- a/server/ControlPlane/Database/Database.cs
+++ b/server/ControlPlane/Database/Database.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Npgsql;
 using Polly;
 using Polly.Retry;
+using Tyger.Common.DependencyInjection;
 using Tyger.ControlPlane.Compute.Kubernetes;
 using Tyger.ControlPlane.Database.Migrations;
 using Tyger.ControlPlane.Model;
@@ -105,10 +106,10 @@ public static class Database
         });
 
         builder.Services.AddSingleton<MigrationRunner>();
-        builder.Services.AddHostedService(sp => sp.GetRequiredService<MigrationRunner>());
+        builder.AddServiceWithPriority(ServiceDescriptor.Singleton<IHostedService>(sp => sp.GetRequiredService<MigrationRunner>()), 200);
 
         builder.Services.AddSingleton<DatabaseVersions>();
-        builder.Services.AddHostedService(sp => sp.GetRequiredService<DatabaseVersions>());
+        builder.AddServiceWithPriority(ServiceDescriptor.Singleton<IHostedService>(sp => sp.GetRequiredService<DatabaseVersions>()), 100);
         builder.Services.AddHealthChecks().AddCheck<DatabaseVersions>("database");
     }
 


### PR DESCRIPTION
In changes #147 and #165 , I created a race condition where the server would sometimes not wait for the database to be initialized before starting to use it. 

The fix is to make sure that `IHostedService` implementations are added to the services collection in an order that respects the implicit dependencies between them.