### PR TITLE
Validate buffer names

### DIFF
--- a/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
+++ b/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
@@ -107,6 +107,8 @@ public partial class DockerRunCreator : RunCreatorBase, IRunCreator, IHostedServ
             throw new ArgumentException($"The codespec for the job is required to be a job codespec");
         }
 
+        Validator.ValidateObject(jobCodespec, new(jobCodespec));
+
         try
         {
             await _client.Images.InspectImageAsync(jobCodespec.Image, cancellationToken: cancellationToken);

--- a/server/ControlPlane/Compute/Kubernetes/KubernetesRunLogReader.cs
+++ b/server/ControlPlane/Compute/Kubernetes/KubernetesRunLogReader.cs
@@ -17,7 +17,6 @@ namespace Tyger.ControlPlane.Compute.Kubernetes;
 
 public class KubernetesRunLogReader : ILogSource
 {
-    private static readonly Pipeline s_emptyPipeline = new([]);
     private readonly k8s.Kubernetes _client;
     private readonly Repository _repository;
     private readonly ILogArchive _logArchive;
@@ -63,7 +62,7 @@ public class KubernetesRunLogReader : ILogSource
             return await FollowLogs(run, options, cancellationToken);
         }
 
-        return (await InnerGetLogs()) ?? s_emptyPipeline;
+        return (await InnerGetLogs()) ?? new([]);
     }
 
     private Task<Pipeline> FollowLogs(Run run, GetLogsOptions options, CancellationToken cancellationToken)

--- a/server/ControlPlane/Compute/Kubernetes/LoggerExtensions.cs
+++ b/server/ControlPlane/Compute/Kubernetes/LoggerExtensions.cs
@@ -20,6 +20,9 @@ public static partial class LoggerExtensions
     [LoggerMessage(LogLevel.Error, "Error creating run {runId} resources.")]
     public static partial void ErrorCreatingRunResources(this ILogger logger, long runId, Exception exception);
 
+    [LoggerMessage(LogLevel.Warning, "Retryable error creating run {runId} resources.")]
+    public static partial void RetryableErrorCreatingRunResources(this ILogger logger, long runId, Exception exception);
+
     [LoggerMessage(LogLevel.Error, "Error while watching resources.")]
     public static partial void ErrorWatchingResources(this ILogger logger, Exception exception);
 

--- a/server/ControlPlane/Database/Repository.cs
+++ b/server/ControlPlane/Database/Repository.cs
@@ -723,9 +723,9 @@ public class Repository
 
             await tx.CommitAsync(cancellationToken);
 
-            if (updatedRun.Status is RunStatus.Succeeded or RunStatus.Failed)
+            if (updatedRun.Status is RunStatus.Succeeded or RunStatus.Failed && updatedRun.FinishedAt.HasValue)
             {
-                var timeToDetect = DateTimeOffset.UtcNow - updatedRun.FinishedAt!.Value;
+                var timeToDetect = DateTimeOffset.UtcNow - updatedRun.FinishedAt.Value;
                 _logger.TerminalStateRecorded(state.Id, timeToDetect);
             }
         }, cancellationToken);

--- a/server/ControlPlane/Model/Model.cs
+++ b/server/ControlPlane/Model/Model.cs
@@ -243,9 +243,9 @@ public partial record JobCodespec : Codespec, IValidatableObject
                     yield return new ValidationResult(string.Format(CultureInfo.InvariantCulture, "All buffer names must be unique across inputs and outputs. Buffer names are case-insensitive. '{0}' is duplicated", group.Key));
                 }
 
-                if (group.Key.Contains('/'))
+                if (!BufferNameRegex().IsMatch(group.Key))
                 {
-                    yield return new ValidationResult(string.Format(CultureInfo.InvariantCulture, "The buffer '{0}' cannot contain '/' in its name.", group.Key));
+                    yield return new ValidationResult(string.Format(CultureInfo.InvariantCulture, "The name of buffer '{0}' is invalid. Buffer names must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character.", group.Key));
                 }
             }
         }
@@ -345,6 +345,9 @@ public partial record JobCodespec : Codespec, IValidatableObject
 
     [GeneratedRegex(@"\$\(([^)]+)\)|\$\$([^)]+)")]
     internal static partial Regex EnvironmentVariableExpansionRegex();
+
+    [GeneratedRegex(@"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")]
+    internal static partial Regex BufferNameRegex();
 }
 
 [Equatable]


### PR DESCRIPTION
Add validation to buffer names defined in codespecs. Also improve error handling when Kubernetes rejects pod specs. 