### PR TITLE
Small changes to improve scalability and logging

### DIFF
--- a/Makefile.cloud
+++ b/Makefile.cloud
@@ -200,7 +200,10 @@ connect-db: set-context
 		--host="$$(echo $${helm_values} | jq -r '.database.host')" \
 		--port="$$(echo $${helm_values} | jq -r '.database.port')" \
 		--username="$$(az account show | jq -r '.user.name')" \
-		--dbname="$$(echo $${helm_values} | jq -r '.database.databaseName')"
+		--dbname="$${DB_NAME:-$$(echo $${helm_values} | jq -r '.database.databaseName')}"
+
+connect-db-query-store:
+	$(MAKE) connect-db DB_NAME=azure_sys
 
 purge-runs: set-context
 	kubectl delete pod,statefulset,secret,service -n "${HELM_NAMESPACE}" -l tyger-run --cascade=foreground

--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -140,6 +140,7 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 			MaxCount:            &clusterConfig.SystemNodePool.MaxCount,
 			OSType:              Ptr(armcontainerservice.OSTypeLinux),
 			OSSKU:               Ptr(armcontainerservice.OSSKUAzureLinux),
+			Tags:                tags,
 		},
 	}
 
@@ -161,6 +162,7 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 			NodeTaints: []*string{
 				Ptr("tyger=run:NoSchedule"),
 			},
+			Tags: tags,
 		}
 
 		if clusterAlreadyExists {
@@ -408,6 +410,21 @@ func clusterNeedsUpdating(cluster, existingCluster armcontainerservice.ManagedCl
 				if *np.OrchestratorVersion != *existingNp.OrchestratorVersion {
 					return true, false
 				}
+
+				if len(np.Tags) != len(existingNp.Tags) {
+					return true, false
+				}
+
+				for k, v := range np.Tags {
+					existingV, ok := existingNp.Tags[k]
+					if !ok {
+						return true, false
+					}
+					if *v != *existingV {
+						return true, false
+					}
+				}
+
 				break
 			}
 		}

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -13,7 +13,7 @@ cloud:
       - name: ${TYGER_ENVIRONMENT_NAME}
         apiHost: true
         sku: Standard
-        kubernetesVersion: "1.28"
+        kubernetesVersion: "1.29"
         systemNodePool:
           name: system
           vmSize: ${TYGER_SYSTEM_NODE_SKU}

--- a/server/ControlPlane/Buffers/Buffers.cs
+++ b/server/ControlPlane/Buffers/Buffers.cs
@@ -74,7 +74,7 @@ public static class Buffers
 
         app.MapGet("/v1/buffers", async (BufferManager manager, HttpContext context, int? limit, [FromQuery(Name = "_ct")] string? continuationToken, CancellationToken cancellationToken) =>
             {
-                limit = limit is null ? 20 : Math.Min(limit.Value, 200);
+                limit = limit is null ? 20 : Math.Min(limit.Value, 2000);
                 var tagQuery = new Dictionary<string, string>();
 
                 foreach (var tag in context.Request.Query)

--- a/server/ControlPlane/Codespecs/Codespecs.cs
+++ b/server/ControlPlane/Codespecs/Codespecs.cs
@@ -57,7 +57,7 @@ public static class Codespecs
 
         app.MapGet("/v1/codespecs", async (Repository repository, int? limit, string? prefix, [FromQuery(Name = "_ct")] string? continuationToken, HttpContext context) =>
         {
-            limit = limit is null ? 20 : Math.Min(limit.Value, 200);
+            limit = limit is null ? 20 : Math.Min(limit.Value, 2000);
             (var codespecs, var nextContinuationToken) = await repository.GetCodespecs(limit.Value, prefix, continuationToken, context.RequestAborted);
 
             string? nextLink;

--- a/server/ControlPlane/Compute/Kubernetes/Kubernetes.cs
+++ b/server/ControlPlane/Compute/Kubernetes/Kubernetes.cs
@@ -23,7 +23,7 @@ public static class Kubernetes
     {
         builder.Services.AddOptions<KubernetesCoreOptions>().BindConfiguration("compute:kubernetes").ValidateDataAnnotations().ValidateOnStart();
 
-        builder.Services.AddSingleton<LoggingHandler>();
+        builder.Services.AddSingleton<KubernetesLogger>();
         builder.Services.AddSingleton(sp =>
         {
             var kubernetesOptions = sp.GetRequiredService<IOptions<KubernetesCoreOptions>>().Value;
@@ -40,7 +40,7 @@ public static class Kubernetes
             var resilienceHander = new ResilienceHandler(pipeline);
 #pragma warning restore EXTEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-            return new k8s.Kubernetes(config, sp.GetRequiredService<LoggingHandler>(), resilienceHander);
+            return new k8s.Kubernetes(config, sp.GetRequiredService<KubernetesLogger>(), resilienceHander);
         });
         builder.Services.AddSingleton<IKubernetes>(sp => sp.GetRequiredService<k8s.Kubernetes>());
 
@@ -128,11 +128,11 @@ public class NodePoolOptions
 /// <summary>
 /// Logs interactions with the Kubernetes API
 /// </summary>
-public class LoggingHandler : DelegatingHandler
+public class KubernetesLogger : DelegatingHandler
 {
-    private readonly ILogger<LoggingHandler> _logger;
+    private readonly ILogger<KubernetesLogger> _logger;
 
-    public LoggingHandler(ILogger<LoggingHandler> logger)
+    public KubernetesLogger(ILogger<KubernetesLogger> logger)
     {
         _logger = logger;
     }

--- a/server/ControlPlane/Compute/Kubernetes/KubernetesRunCreator.cs
+++ b/server/ControlPlane/Compute/Kubernetes/KubernetesRunCreator.cs
@@ -159,6 +159,8 @@ public class KubernetesRunCreator : RunCreatorBase, IRunCreator, ICapabilitiesCo
                 throw new ArgumentException($"The codespec for the worker is required to be a worker codespec");
             }
 
+            Validator.ValidateObject(workerCodespec, new(workerCodespec));
+
             run = run with
             {
                 Worker = run.Worker with

--- a/server/ControlPlane/Compute/Kubernetes/KubernetesRunReader.cs
+++ b/server/ControlPlane/Compute/Kubernetes/KubernetesRunReader.cs
@@ -14,13 +14,13 @@ public partial class KubernetesRunReader : IRunReader
 {
     private readonly Repository _repository;
     private readonly RunChangeFeed _changeFeed;
+    private readonly ILogger<KubernetesRunReader> _logger;
 
-    public KubernetesRunReader(
-        Repository repository,
-        RunChangeFeed changeFeed)
+    public KubernetesRunReader(Repository repository, RunChangeFeed changeFeed, ILogger<KubernetesRunReader> logger)
     {
         _repository = repository;
         _changeFeed = changeFeed;
+        _logger = logger;
     }
 
     public async Task<IDictionary<RunStatus, long>> GetRunCounts(DateTimeOffset? since, Dictionary<string, string>? tags, CancellationToken cancellationToken)
@@ -97,6 +97,7 @@ public partial class KubernetesRunReader : IRunReader
 
                 if (run.Status!.Value.IsTerminal())
                 {
+                    _logger.WatchReachedTerminalState(run.Status!.Value, run.Id!.Value);
                     yield break;
                 }
             }

--- a/server/ControlPlane/Compute/Kubernetes/RunStateObserver.cs
+++ b/server/ControlPlane/Compute/Kubernetes/RunStateObserver.cs
@@ -15,7 +15,7 @@ namespace Tyger.ControlPlane.Compute.Kubernetes;
 /// </summary>
 public class RunStateObserver : BackgroundService
 {
-    private const int PartitionCount = 8;
+    private const int PartitionCount = 128;
     private const int ParitionChannelSize = 1024;
 
     private readonly IKubernetes _kubernetesClient;
@@ -235,7 +235,8 @@ public class RunStateObserver : BackgroundService
             var previousState = runObjects.CachedMetadata;
             var currentState = runObjects.GetObservedState();
 
-            if (!previousState.Equals(currentState))
+            // Pending is state when the run is created, so no need to update it.
+            if (currentState.Status != Model.RunStatus.Pending && !previousState.Equals(currentState))
             {
                 await _repository.UpdateRunFromObservedState(currentState, (_leaseManager.LeaseName, _thisLeaseHolderId), stoppingToken);
             }

--- a/server/ControlPlane/Compute/LoggerExtensions.cs
+++ b/server/ControlPlane/Compute/LoggerExtensions.cs
@@ -32,17 +32,14 @@ public static partial class LoggerExtensions
     [LoggerMessage(LogLevel.Warning, "Deleting run {run} that never created resources")]
     public static partial void DeletingRunThatNeverCreatedResources(this ILogger logger, long run);
 
-    [LoggerMessage(LogLevel.Information, "Finalizing run {run} with status {status}")]
-    public static partial void FinalizingTerminatedRun(this ILogger logger, long run, RunStatus status);
+    [LoggerMessage(LogLevel.Information, "Finalizing run {runId} with status {status}")]
+    public static partial void FinalizingTerminatedRun(this ILogger logger, long runId, RunStatus status);
 
-    [LoggerMessage(LogLevel.Warning, "Failed to finalize run {run}")]
-    public static partial void ErrorDuringFinalization(this ILogger logger, long run, Exception exception);
+    [LoggerMessage(LogLevel.Warning, "Failed to finalize run {runId}")]
+    public static partial void ErrorDuringFinalization(this ILogger logger, long runId, Exception exception);
 
-    [LoggerMessage(LogLevel.Error, "Unhandled background exception when following logs")]
-    public static partial void UnexpectedExceptionDuringWatch(this ILogger logger, Exception exception);
-
-    [LoggerMessage(LogLevel.Information, "Restarting watch after exception")]
-    public static partial void RestartingWatchAfterException(this ILogger logger, Exception exception);
+    [LoggerMessage(LogLevel.Information, "Watch reached terminal status {status} for run {runId}")]
+    public static partial void WatchReachedTerminalState(this ILogger logger, RunStatus status, long runId);
 
     [LoggerMessage(LogLevel.Warning, "RunStateObserver channel {partition} has high count of {count}")]
     public static partial void RunStateObserverHighQueueLength(this ILogger logger, int partition, int count);

--- a/server/ControlPlane/Database/LoggerExtensions.cs
+++ b/server/ControlPlane/Database/LoggerExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Tyger.ControlPlane.Model;
+
 namespace Tyger.ControlPlane.Database;
 
 public static partial class LoggerExtensions
@@ -17,8 +19,8 @@ public static partial class LoggerExtensions
     [LoggerMessage(LogLevel.Information, "Duplicate idempotency key {idempotencyKey} received")]
     public static partial void DuplicateIdempotencyKeyReceived(this ILogger logger, string idempotencyKey);
 
-    [LoggerMessage(LogLevel.Information, "Terminal state recorded for {runid} with latency {timeToDetect}")]
-    public static partial void TerminalStateRecorded(this ILogger logger, long runId, TimeSpan timeToDetect);
+    [LoggerMessage(LogLevel.Information, "Terminal status {status} recorded for {runId} with latency {timeToDetect}")]
+    public static partial void TerminalStateRecorded(this ILogger logger, RunStatus status, long runId, TimeSpan timeToDetect);
 
     [LoggerMessage(LogLevel.Warning, "Exception occured while acquiring or renewing lease {leaseName}")]
     public static partial void LeaseException(this ILogger logger, string leaseName, Exception exception);
@@ -35,4 +37,6 @@ public static partial class LoggerExtensions
     [LoggerMessage(LogLevel.Information, "Released lease {leaseName}")]
     public static partial void LeaseReleased(this ILogger logger, string leaseName);
 
+    [LoggerMessage(LogLevel.Information, "Update run from observed run state {durationMilliseconds}ms")]
+    public static partial void UpdateRunFromObservedState(this ILogger logger, int durationMilliseconds);
 }

--- a/server/ControlPlane/Database/Migrations/LoggerExtensions.cs
+++ b/server/ControlPlane/Database/Migrations/LoggerExtensions.cs
@@ -11,11 +11,11 @@ public static partial class LoggerExtensions
     [LoggerMessage(LogLevel.Error, "Failed to read database version")]
     public static partial void FailedToReadDatabaseVersion(this ILogger logger, Exception exception);
 
-    [LoggerMessage(LogLevel.Information, "Applying migration {Id}")]
-    public static partial void ApplyingMigration(this ILogger logger, int Id);
+    [LoggerMessage(LogLevel.Information, "Applying migration {id}")]
+    public static partial void ApplyingMigration(this ILogger logger, int id);
 
-    [LoggerMessage(LogLevel.Information, "Migration {Id} complete")]
-    public static partial void MigrationComplete(this ILogger logger, int Id);
+    [LoggerMessage(LogLevel.Information, "Migration {id} complete")]
+    public static partial void MigrationComplete(this ILogger logger, int id);
 
     [LoggerMessage(LogLevel.Error, "Migration {Id} failed")]
     public static partial void MigrationFailed(this ILogger logger, int Id, Exception exception);

--- a/server/ControlPlane/Database/Repository.cs
+++ b/server/ControlPlane/Database/Repository.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Data;
+using System.Diagnostics;
 using System.IO.Hashing;
 using System.Text;
 using System.Text.Json;
@@ -642,6 +643,7 @@ public class Repository
 
     public async Task UpdateRunFromObservedState(ObservedRunState state, (string leaseName, string holder)? leaseHeldCondition, CancellationToken cancellationToken)
     {
+        var start = Stopwatch.GetTimestamp();
         await _resiliencePipeline.ExecuteAsync(async cancellationToken =>
         {
             await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken);
@@ -726,9 +728,12 @@ public class Repository
             if (updatedRun.Status is RunStatus.Succeeded or RunStatus.Failed && updatedRun.FinishedAt.HasValue)
             {
                 var timeToDetect = DateTimeOffset.UtcNow - updatedRun.FinishedAt.Value;
-                _logger.TerminalStateRecorded(state.Id, timeToDetect);
+                _logger.TerminalStateRecorded(updatedRun.Status.Value, state.Id, timeToDetect);
             }
         }, cancellationToken);
+
+        var end = Stopwatch.GetTimestamp();
+        _logger.UpdateRunFromObservedState((int)((end - start) / (double)Stopwatch.Frequency * 1000));
     }
 
     public async Task ForceUpdateRun(Run run, CancellationToken cancellationToken)
@@ -799,7 +804,7 @@ public class Repository
             await using var cmd = new NpgsqlCommand($"""
                 SELECT run, final, logs_archived_at, resources_created, modified_at, tags_version {((options & GetRunOptions.SkipTags) == GetRunOptions.SkipTags ? "" : ", tag_keys.name, run_tags.value")}
                 FROM runs
-                {((options & GetRunOptions.SkipTags) == GetRunOptions.SkipTags ? "" : "LEFT JOIN run_tags ON runs.id = run_tags.id LEFT JOIN tag_keys ON run_tags.key = tag_keys.id")}
+                {((options & GetRunOptions.SkipTags) == GetRunOptions.SkipTags ? "" : "LEFT JOIN run_tags ON runs.created_at = run_tags.created_at AND runs.id = run_tags.id LEFT JOIN tag_keys ON run_tags.key = tag_keys.id")}
                 WHERE runs.id = $1
                 {((options & GetRunOptions.SkipTags) == GetRunOptions.SkipTags ? "" : "ORDER BY tag_keys.name")}
                 """, conn)
@@ -849,16 +854,19 @@ public class Repository
                 return null;
             }
 
-            run = run with { Tags = tags };
-            var hash = _xxHash3Pool.Get();
-            try
+            if ((options & GetRunOptions.SkipTags) != GetRunOptions.SkipTags)
             {
-                run.ComputeEtag(hash);
-            }
-            finally
-            {
-                hash.Reset();
-                _xxHash3Pool.Return(hash);
+                run = run with { Tags = tags };
+                var hash = _xxHash3Pool.Get();
+                try
+                {
+                    run.ComputeEtag(hash);
+                }
+                finally
+                {
+                    hash.Reset();
+                    _xxHash3Pool.Return(hash);
+                }
             }
 
             return (run, modifiedAt, logsArchivedAt, final, tagsVersion);

--- a/server/ControlPlane/Logging/LoggerExtensions.cs
+++ b/server/ControlPlane/Logging/LoggerExtensions.cs
@@ -5,11 +5,11 @@ namespace Tyger.ControlPlane.Logging;
 
 public static partial class LoggerExtensions
 {
-    [LoggerMessage(LogLevel.Information, "Archived logs for run {run}")]
-    public static partial void ArchivedLogsForRun(this ILogger logger, long run);
+    [LoggerMessage(LogLevel.Information, "Archived logs for run {runId}")]
+    public static partial void ArchivedLogsForRun(this ILogger logger, long runId);
 
-    [LoggerMessage(LogLevel.Information, "Retrieving archived logs for run {run}")]
-    public static partial void RetrievingArchivedLogsForRun(this ILogger logger, long run);
+    [LoggerMessage(LogLevel.Information, "Retrieving archived logs for run {runId}")]
+    public static partial void RetrievingArchivedLogsForRun(this ILogger logger, long runId);
 
     [LoggerMessage(LogLevel.Information, "Resuming logs after exception.")]
     public static partial void ResumingLogsAfterException(this ILogger logger, Exception exception);

--- a/server/ControlPlane/Runs/Runs.cs
+++ b/server/ControlPlane/Runs/Runs.cs
@@ -54,7 +54,7 @@ public static class Runs
 
         app.MapGet("/v1/runs", async (IRunReader runReader, int? limit, DateTimeOffset? since, [FromQuery(Name = "status")] string[]? statuses, [FromQuery(Name = "_ct")] string? continuationToken, HttpContext context) =>
         {
-            limit = limit is null ? 20 : Math.Min(limit.Value, 200);
+            limit = limit is null ? 20 : Math.Min(limit.Value, 2000);
 
             if (statuses != null)
             {

--- a/server/ControlPlane/appsettings.json
+++ b/server/ControlPlane/appsettings.json
@@ -1,8 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Warning",
+      "Tyger": "Information"
     },
     "Console": {
       "FormatterName": "Tyger.Common.Logging.JsonFormatter"

--- a/server/DataPlane/appsettings.json
+++ b/server/DataPlane/appsettings.json
@@ -1,8 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Warning",
+      "Tyger": "Information"
     },
     "Console": {
       "FormatterName": "Tyger.Common.Logging.JsonFormatter"


### PR DESCRIPTION
Addressing a few bottlenecks encountered when pushing a Tyger cluster to nearly 300K runs/hour.

1. Missing a column in a `JOIN` clause resulted in excessive CPU usage.
2. Reducing redundant updates to run records in the database.
3. Ensuring a couple of channels do not get backed up.