### PR TITLE
Ensure output buffers marked finished when run is canceled.

### DIFF
--- a/cli/cmd/buffer-sidecar/lifetime.go
+++ b/cli/cmd/buffer-sidecar/lifetime.go
@@ -49,7 +49,7 @@ func tryOpenFileUntilContainerExits(ctx context.Context, namespace, podName, con
 		// Create Kubernetes client
 		config, err := rest.InClusterConfig()
 		if err != nil {
-			// If not running in a cluster, we might be runinning on a workstation for development.
+			// If not running in a cluster, we might be running on a workstation for development.
 			configPath := filepath.Join(homedir.HomeDir(), ".kube", "config")
 			configBytes, err := os.ReadFile(configPath)
 			if err == nil {

--- a/cli/cmd/buffer-sidecar/lifetime.go
+++ b/cli/cmd/buffer-sidecar/lifetime.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -19,12 +20,14 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 )
 
-func tryOpenFileUntilContainerExits(namespace, podName, containerName, tombstoneFilePath string, filePath string, flag int, perm fs.FileMode) (*os.File, error) {
+func tryOpenFileUntilContainerExits(ctx context.Context, namespace, podName, containerName, tombstoneFilePath string, filePath string, flag int, perm fs.FileMode) (*os.File, error) {
 	// Create cancellable contexts
-	openFileCtx, openFileCancel := context.WithCancel(context.Background())
-	watchCtx, watchCancel := context.WithCancel(context.Background())
+	openFileCtx, openFileCancel := context.WithCancel(ctx)
+	watchCtx, watchCancel := context.WithCancel(ctx)
 	defer watchCancel()
 
 	if tombstoneFilePath != "" {
@@ -46,7 +49,19 @@ func tryOpenFileUntilContainerExits(namespace, podName, containerName, tombstone
 		// Create Kubernetes client
 		config, err := rest.InClusterConfig()
 		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to load in-cluster Kubernetes config")
+			// If not running in a cluster, we might be runinning on a workstation for development.
+			configPath := filepath.Join(homedir.HomeDir(), ".kube", "config")
+			configBytes, err := os.ReadFile(configPath)
+			if err == nil {
+				if cc, err := clientcmd.NewClientConfigFromBytes(configBytes); err == nil {
+					if clientConfig, err := cc.ClientConfig(); err == nil {
+						config = clientConfig
+					}
+				}
+			}
+		}
+		if config == nil {
+			log.Fatal().Err(err).Msg("Failed to create Kubernetes client config")
 		}
 		clientset, err := kubernetes.NewForConfig(config)
 		if err != nil {

--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -1535,7 +1535,7 @@ timeoutSeconds: 600`, BasicImage)
 	out, stdErr, err := runTyger("buffer", "read", outputBufferId)
 	require.Len(out, 0)
 
-	// It's a race condition whether the pod was started before the cancel request was processed.
+	// There is a race condition based on whether the pod starts before the cancel request is processed.
 	// If the pod was started, the the buffer should be marked as completed because of the INT signal handler.
 	// If not, it will be marked as failed.
 

--- a/cli/internal/controlplane/model/model.go
+++ b/cli/internal/controlplane/model/model.go
@@ -25,7 +25,7 @@ type Buffer struct {
 	CreatedAt time.Time         `json:"createdAt"`
 	Location  string            `json:"location,omitempty"`
 	Tags      map[string]string `json:"tags,omitempty"`
-	ETag      string            `json:"eTag"`
+	ETag      string            `json:"eTag,omitempty"`
 }
 
 type BufferAccess struct {
@@ -140,7 +140,7 @@ type Run struct {
 	Cluster        string            `json:"cluster,omitempty"`
 	TimeoutSeconds *int              `json:"timeoutSeconds,omitempty"`
 	Tags           map[string]string `json:"tags,omitempty"`
-	ETag           string            `json:"eTag"`
+	ETag           string            `json:"eTag,omitempty"`
 }
 
 type RunStatus uint

--- a/cli/internal/controlplane/requests.go
+++ b/cli/internal/controlplane/requests.go
@@ -63,8 +63,9 @@ func InvokeRequest(ctx context.Context, method string, relativeUri string, input
 
 	absoluteUri := fmt.Sprintf("%s/%s", tygerClient.ControlPlaneUrl, relativeUri)
 	var body io.Reader = nil
+	var serializedBody []byte
 	if input != nil {
-		serializedBody, err := json.Marshal(input)
+		serializedBody, err = json.Marshal(input)
 		if err != nil {
 			return nil, fmt.Errorf("unable to serialize payload: %v", err)
 		}
@@ -92,6 +93,7 @@ func InvokeRequest(ctx context.Context, method string, relativeUri string, input
 		if token != "" {
 			req.Header.Add("Authorization", "Bearer --REDACTED--")
 		}
+		req.Request.Body = io.NopCloser(bytes.NewBuffer(serializedBody))
 		if debugOutput, err := httputil.DumpRequestOut(req.Request, true); err == nil {
 			log.Trace().Str("request", string(debugOutput)).Msg("Outgoing request")
 		}

--- a/server/ControlPlane/Buffers/BufferMetadata.cs
+++ b/server/ControlPlane/Buffers/BufferMetadata.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Tyger.ControlPlane.Buffers;
+
+public static class BufferMetadata
+{
+    public const string EndMetadataBlobName = ".bufferend";
+    public static readonly byte[] FailedEndMetadataContent = "{\"status\":\"failed\"}"u8.ToArray();
+}

--- a/server/ControlPlane/Buffers/IBufferProvider.cs
+++ b/server/ControlPlane/Buffers/IBufferProvider.cs
@@ -15,6 +15,8 @@ public interface IBufferProvider
 
     Task<Run> ExportBuffers(ExportBuffersRequest exportBufferRequest, CancellationToken cancellationToken);
     Task<Run> ImportBuffers(ImportBuffersRequest importBuffersRequest, CancellationToken cancellationToken);
+
+    Task TryMarkBufferAsFailed(string id, CancellationToken cancellationToken);
 }
 
 public interface IEphemeralBufferProvider

--- a/server/ControlPlane/Buffers/LoggerExtensions.cs
+++ b/server/ControlPlane/Buffers/LoggerExtensions.cs
@@ -13,4 +13,7 @@ public static partial class LogingExtensions
 
     [LoggerMessage(LogLevel.Error, "Failed to refresh user delegation key (expired)")]
     public static partial void FailedToRefreshExpiredUserDelegationKey(this ILogger logger, Exception ex);
+
+    [LoggerMessage(LogLevel.Warning, "Failed to mark buffer as failed")]
+    public static partial void FailedToMarkBufferAsFailed(this ILogger logger, Exception ex);
 }

--- a/server/ControlPlane/Codespecs/CodespecReader.cs
+++ b/server/ControlPlane/Codespecs/CodespecReader.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Tyger.ControlPlane.Database;
+using Tyger.ControlPlane.Model;
+
+namespace Tyger.ControlPlane.Codespecs;
+
+public class CodespecReader
+{
+    private readonly Repository _repository;
+
+    public CodespecReader(Repository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Codespec> GetCodespec(ICodespecRef codespecRef, CancellationToken cancellationToken)
+    {
+        if (codespecRef is Codespec inlineCodespec)
+        {
+            return inlineCodespec;
+        }
+
+        if (codespecRef is not CommittedCodespecRef committedCodespecRef)
+        {
+            throw new InvalidOperationException("Invalid codespec reference");
+        }
+
+        if (committedCodespecRef.Version == null)
+        {
+            return await _repository.GetLatestCodespec(committedCodespecRef.Name, cancellationToken)
+                ?? throw new ValidationException(string.Format(CultureInfo.InvariantCulture, "The codespec '{0}' was not found", committedCodespecRef.Name));
+        }
+
+        var codespec = await _repository.GetCodespecAtVersion(committedCodespecRef.Name, committedCodespecRef.Version.Value, cancellationToken);
+        if (codespec == null)
+        {
+            // See if it's just the version number that was not found
+            var latestCodespec = await _repository.GetLatestCodespec(committedCodespecRef.Name, cancellationToken)
+                ?? throw new ValidationException(string.Format(CultureInfo.InvariantCulture, "The codespec '{0}' was not found", committedCodespecRef.Name));
+
+            throw new ValidationException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "The version '{0}' of codespec '{1}' was not found. The latest version is '{2}'.",
+                    committedCodespecRef.Version, committedCodespecRef.Name, latestCodespec.Version));
+        }
+
+        return codespec;
+    }
+}

--- a/server/ControlPlane/Codespecs/Codespecs.cs
+++ b/server/ControlPlane/Codespecs/Codespecs.cs
@@ -16,6 +16,11 @@ namespace Tyger.ControlPlane.Codespecs;
 
 public static class Codespecs
 {
+    public static void AddCodespecs(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton<CodespecReader>();
+    }
+
     public static void MapCodespecs(this WebApplication app)
     {
         app.MapPut("/v1/codespecs/{name}", async (string name, Repository repository, HttpContext context) =>

--- a/server/ControlPlane/Json/Normalizer.cs
+++ b/server/ControlPlane/Json/Normalizer.cs
@@ -45,8 +45,8 @@ public static class Normalizer
             foreach (var property in value.GetType().GetProperties())
             {
                 if (Attribute.IsDefined(property, typeof(CompilerGeneratedAttribute)) ||
-                    (property.GetCustomAttribute<JsonIgnoreAttribute>() is JsonIgnoreAttribute ignoreAttribute &&
-                    ignoreAttribute.Condition == JsonIgnoreCondition.Always))
+                    (property.GetCustomAttribute<JsonIgnoreAttribute>() is JsonIgnoreAttribute ignoreAttribute && ignoreAttribute.Condition == JsonIgnoreCondition.Always) ||
+                    Attribute.IsDefined(property, typeof(SkipEmptyToNullNormalizationAttribute)))
                 {
                     continue;
                 }
@@ -76,4 +76,9 @@ public static class Normalizer
 
         return (T?)NormalizeImpl(value);
     }
+}
+
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class SkipEmptyToNullNormalizationAttribute : Attribute
+{
 }

--- a/server/ControlPlane/Model/Model.cs
+++ b/server/ControlPlane/Model/Model.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Generator.Equals;
 using k8s.Models;
+using Tyger.ControlPlane.Json;
 
 namespace Tyger.ControlPlane.Model;
 
@@ -52,6 +53,7 @@ public record Buffer : ModelBase
 
     public IReadOnlyDictionary<string, string>? Tags { get; init; }
 
+    [SkipEmptyToNullNormalization]
     public string? ETag
     {
         get => _etag ??= ComputeEtagCore(new()); set => _etag = value;
@@ -478,6 +480,7 @@ public partial record Run : ModelBase
     /// <summary>
     /// The ETag that can be used for optimistic concurrency. Populated by the system.
     /// </summary>
+    [SkipEmptyToNullNormalization]
     public string? ETag
     {
         get => _etag ??= ComputeEtagCore(new()); set => _etag = value;

--- a/server/ControlPlane/Program.cs
+++ b/server/ControlPlane/Program.cs
@@ -49,6 +49,7 @@ void RunServer()
     var builder = WebApplication.CreateBuilder();
 
     AddCommonServices(builder);
+    builder.AddCodespecs();
     builder.AddLogArchive();
     builder.AddAuth();
     builder.AddRuns();

--- a/server/ControlPlane/Runs/RunCreatorBase.cs
+++ b/server/ControlPlane/Runs/RunCreatorBase.cs
@@ -21,41 +21,6 @@ public abstract class RunCreatorBase : BackgroundService
 
     protected BufferManager BufferManager { get; init; }
 
-    protected async Task<Codespec> GetCodespec(ICodespecRef codespecRef, CancellationToken cancellationToken)
-    {
-        if (codespecRef is Codespec inlineCodespec)
-        {
-            return inlineCodespec;
-        }
-
-        if (codespecRef is not CommittedCodespecRef committedCodespecRef)
-        {
-            throw new InvalidOperationException("Invalid codespec reference");
-        }
-
-        if (committedCodespecRef.Version == null)
-        {
-            return await Repository.GetLatestCodespec(committedCodespecRef.Name, cancellationToken)
-                ?? throw new ValidationException(string.Format(CultureInfo.InvariantCulture, "The codespec '{0}' was not found", committedCodespecRef.Name));
-        }
-
-        var codespec = await Repository.GetCodespecAtVersion(committedCodespecRef.Name, committedCodespecRef.Version.Value, cancellationToken);
-        if (codespec == null)
-        {
-            // See if it's just the version number that was not found
-            var latestCodespec = await Repository.GetLatestCodespec(committedCodespecRef.Name, cancellationToken)
-                ?? throw new ValidationException(string.Format(CultureInfo.InvariantCulture, "The codespec '{0}' was not found", committedCodespecRef.Name));
-
-            throw new ValidationException(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    "The version '{0}' of codespec '{1}' was not found. The latest version is '{2}'.",
-                    committedCodespecRef.Version, committedCodespecRef.Name, latestCodespec.Version));
-        }
-
-        return codespec;
-    }
-
     protected async Task ProcessBufferArguments(BufferParameters? parameters, Dictionary<string, string> arguments, Dictionary<string, string>? tags, CancellationToken cancellationToken)
     {
         if (arguments != null)


### PR DESCRIPTION
When a run is canceled, we ensure that its output buffers are all terminated. If they are not already completed at the time of finalization, they are marked as failed. This prevents `tyger buffer read` from hanging.