### PR TITLE
Adjust database permissions

### DIFF
--- a/cli/internal/cmd/install/config.go
+++ b/cli/internal/cmd/install/config.go
@@ -24,7 +24,6 @@ import (
 	"github.com/a8m/envsubst"
 	"github.com/eiannone/keyboard"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/ipinfo/go/v2/ipinfo"
 	"github.com/microsoft/tyger/cli/internal/dataplane"
 	"github.com/microsoft/tyger/cli/internal/install/cloudinstall"
 	"github.com/microsoft/tyger/cli/internal/install/dockerinstall"
@@ -246,20 +245,14 @@ func generateCloudConfig(ctx context.Context, configFile *os.File) error {
 		return errors.New("please install the Azure CLI (az) first")
 	}
 
-	ipInfoClient := ipinfo.NewClient(nil, nil, "")
-	ip, err := ipInfoClient.GetIPInfo(nil)
-	if err != nil {
-		return fmt.Errorf("failed to get current external IP address: %w", err)
-	}
-
 	templateValues := cloudinstall.ConfigTemplateValues{
 		KubernetesVersion:    cloudinstall.DefaultKubernetesVersion,
 		PostgresMajorVersion: cloudinstall.DefaultPostgresMajorVersion,
-		CurrentIpAddress:     ip.IP.String(),
 	}
 
 	fmt.Printf("\nLet's collect settings for the Azure subscription to use. This is where cloud resources will be deployed.\n\n")
 
+	var err error
 	var cred azcore.TokenCredential
 
 	for {

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -118,7 +118,6 @@ type DatabaseConfig struct {
 	Location             string          `json:"location"`
 	ComputeTier          string          `json:"computeTier"`
 	VMSize               string          `json:"vmSize"`
-	OwnerGroup           string          `json:"ownerGroup"`
 	FirewallRules        []*FirewallRule `json:"firewallRules,omitempty"`
 	PostgresMajorVersion int             `json:"postgresMajorVersion"`
 	StorageSizeGB        int             `json:"storageSizeGB"`

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -118,6 +118,7 @@ type DatabaseConfig struct {
 	Location             string          `json:"location"`
 	ComputeTier          string          `json:"computeTier"`
 	VMSize               string          `json:"vmSize"`
+	OwnerGroup           string          `json:"ownerGroup"`
 	FirewallRules        []*FirewallRule `json:"firewallRules,omitempty"`
 	PostgresMajorVersion int             `json:"postgresMajorVersion"`
 	StorageSizeGB        int             `json:"storageSizeGB"`
@@ -174,7 +175,6 @@ type ConfigTemplateValues struct {
 	LogsStorageAccountName   string
 	DomainName               string
 	ApiTenantId              string
-	CurrentIpAddress         string
 	CpuNodePoolMinCount      int
 	GpuNodePoolMinCount      int
 }

--- a/cli/internal/install/cloudinstall/config.tpl
+++ b/cli/internal/install/cloudinstall/config.tpl
@@ -72,10 +72,10 @@ cloud:
 
     # Firewall rules to control where the database can be accessed from,
     # in addition to the control-plane cluster.
-    firewallRules:
-      - name: installerIpAddress
-        startIpAddress: {{ .CurrentIpAddress }}
-        endIpAddress: {{ .CurrentIpAddress }}
+    # firewallRules:
+    #  - name:
+    #    startIpAddress:
+    #    endIpAddress:
 
     # location: Defaults to defaultLocation
     # computeTier: Defaults to Burstable

--- a/cli/internal/install/cloudinstall/database.go
+++ b/cli/internal/install/cloudinstall/database.go
@@ -430,7 +430,7 @@ func (inst *Installer) createRoles(
 		err = db.PingContext(ctx)
 	}
 	if err != nil {
-		log.Warn().Msgf("For network connectivity problems to the database, try adding your current public IP address to the database firewall rules in the config file and verify that there is no firewall in your environment that is blocking aceess to %s on port %d.", *server.Properties.FullyQualifiedDomainName, databasePort)
+		log.Warn().Msgf("For network connectivity problems to the database, try adding your current public IP address to the database firewall rules in the config file and verify that there is no firewall in your environment that is blocking access to %s on port %d.", *server.Properties.FullyQualifiedDomainName, databasePort)
 		return fmt.Errorf("failed to open database connection: %w", err)
 	}
 	defer db.Close()

--- a/cli/internal/install/cloudinstall/database.go
+++ b/cli/internal/install/cloudinstall/database.go
@@ -295,7 +295,7 @@ func (inst *Installer) createDatabase(ctx context.Context, tygerServerManagedIde
 	// Get the current IP address. Create a new "clean" HTTP client that does not use any proxy, as database connections will not use one.
 	ipInfoClient := ipinfo.NewClient(cleanhttp.DefaultClient(), nil, "")
 	if ip, err := ipInfoClient.GetIPInfo(nil); err != nil {
-		log.Warn().Msgf("Unable to determine the current public IP address. You may need to add the current IP address manually to the as a database firewall rule to allow connectivity")
+		log.Warn().Msgf("Unable to determine the current public IP address. You may need to add the current IP address manually as a database firewall rule to allow connectivity")
 	} else {
 		temporaryFirewallRule = &armpostgresqlflexibleservers.FirewallRule{
 			Properties: &armpostgresqlflexibleservers.FirewallRuleProperties{

--- a/docs/introduction/installation/cloud-installation.md
+++ b/docs/introduction/installation/cloud-installation.md
@@ -118,10 +118,10 @@ cloud:
 
     # Firewall rules to control where the database can be accessed from,
     # in addition to the control-plane cluster.
-    firewallRules:
-      - name: installerIpAddress
-        startIpAddress: 99.99.99.99
-        endIpAddress: 99.99.99.99
+    # firewallRules:
+    #   - name:
+    #     startIpAddress:
+    #     endIpAddress:
 
     # location: Defaults to defaultLocation
     # computeTier: Defaults to Burstable

--- a/server/ControlPlane/Database/Migrations/1.cs
+++ b/server/ControlPlane/Database/Migrations/1.cs
@@ -11,16 +11,6 @@ public class Migrator1 : Migrator
     {
         await using var batch = dataSource.CreateBatch();
 
-        batch.BatchCommands.Add(new($"""
-            DO $$
-            BEGIN
-                IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{OwnersRole}') THEN
-                    CREATE ROLE "{OwnersRole}";
-                END IF;
-            END
-            $$
-            """));
-
         // migrations table
 
         batch.BatchCommands.Add(new($"""

--- a/server/ControlPlane/Database/Migrations/1.cs
+++ b/server/ControlPlane/Database/Migrations/1.cs
@@ -11,6 +11,16 @@ public class Migrator1 : Migrator
     {
         await using var batch = dataSource.CreateBatch();
 
+        batch.BatchCommands.Add(new($"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{OwnersRole}') THEN
+                    CREATE ROLE "{OwnersRole}";
+                END IF;
+            END
+            $$
+            """));
+
         // migrations table
 
         batch.BatchCommands.Add(new($"""


### PR DESCRIPTION
1. Ensure that all tables and sequences are owned by the `tyger-owners` database group. With this, anyone in that group can alter these objects' schemas. Currently, if the `tyger-migration-runner` managed identity were to be (accidentally) deleted, no identity would be able to alter the schema.
2. Create a temporary database firewall rule to allow database role initialization. Ensure that automatic proxy discovery is disabled for when determining the IP address. 