### PR TITLE
Associate storage accounts with an NSP profile.

### DIFF
--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -105,6 +105,16 @@ type NodePoolConfig struct {
 type StorageConfig struct {
 	Buffers []*StorageAccountConfig `json:"buffers"`
 	Logs    *StorageAccountConfig   `json:"logs"`
+
+	// Internal support for associating the storage accounts with a network security perimeter profile
+	NetworkSecurityPerimeter *NetworkSecurityPerimeterConfig `json:"networkSecurityPerimeter"`
+}
+
+type NetworkSecurityPerimeterConfig struct {
+	NspResourceGroup string `json:"nspResourceGroup"`
+	NspName          string `json:"nspName"`
+	Profile          string `json:"profile"`
+	Mode             string `json:"mode"`
 }
 
 type StorageAccountConfig struct {

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -51,6 +51,12 @@ cloud:
     logs:
       name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}tygerlog
 
+    networkSecurityPerimeter:
+      nspResourceGroup: NSP-ALL
+      nspName: defaultNSP
+      profile: storageaccounts
+      mode: Learning
+
   database:
     location: ${TYGER_DATABASE_LOCATION}
     firewallRules: ${TYGER_ENVIRONMENT_FIREWALL_RULES}


### PR DESCRIPTION
Adding support for associating storage accounts with a network security perimeter profile as an undocumented feature. This is for compliance with internal policies and will likely be changed or removed when we provide proper support for private networking.