### PR TITLE
Make `buffers` config optional for backward compatibility

### DIFF
--- a/Makefile.cloud
+++ b/Makefile.cloud
@@ -105,8 +105,8 @@ set-localsettings: set-context
 				},
 				"bufferSidecarImage": "$$(echo '${ENVIRONMENT_CONFIG_JSON}' | jq -r '.api.helm.tyger.values.bufferSidecarImage')",
 				"bufferCopierImage": "$$(echo '${ENVIRONMENT_CONFIG_JSON}' | jq -r '.api.helm.tyger.values.bufferCopierImage')",
-				"activeLifetime": "$$(echo $${helm_values} | jq -r '.api.buffers.activeLifetime')",
-				"softDeletedLifetime": "$$(echo $${helm_values} | jq -r '.api.buffers.softDeletedLifetime')"
+				"activeLifetime": "$$(echo $${helm_values} | jq -r '.buffers.activeLifetime')",
+				"softDeletedLifetime": "$$(echo $${helm_values} | jq -r '.buffers.softDeletedLifetime')"
 			},
 			"database": {
 				"host": "$$(echo $${helm_values} | jq -r '.database.host')",

--- a/cli/internal/install/cloudinstall/validation.go
+++ b/cli/internal/install/cloudinstall/validation.go
@@ -367,24 +367,23 @@ func (inst *Installer) quickValidateApiConfig(success *bool) {
 	}
 
 	if apiConfig.Buffers == nil {
-		validationError(success, "The `api.buffers` field is required")
-	} else {
-		buffersConfig := apiConfig.Buffers
-		if buffersConfig.ActiveLifetime == "" {
-			buffersConfig.ActiveLifetime = "0.00:00"
-		}
+		apiConfig.Buffers = &BuffersConfig{}
+	}
+	buffersConfig := apiConfig.Buffers
+	if buffersConfig.ActiveLifetime == "" {
+		buffersConfig.ActiveLifetime = "0.00:00"
+	}
 
-		if buffersConfig.SoftDeletedLifetime == "" {
-			buffersConfig.SoftDeletedLifetime = "0.00:00"
-		}
+	if buffersConfig.SoftDeletedLifetime == "" {
+		buffersConfig.SoftDeletedLifetime = "1.00:00"
+	}
 
-		if _, err := common.ParseTimeToLive(buffersConfig.ActiveLifetime); err != nil {
-			validationError(success, "The `api.buffers.activeLifetime` field must be a valid TTL (D.HH:MM:SS)")
-		}
+	if _, err := common.ParseTimeToLive(buffersConfig.ActiveLifetime); err != nil {
+		validationError(success, "The `api.buffers.activeLifetime` field must be a valid TTL (D.HH:MM:SS)")
+	}
 
-		if _, err := common.ParseTimeToLive(buffersConfig.SoftDeletedLifetime); err != nil {
-			validationError(success, "The `api.buffers.softDeletedLifetime` field be a valid TTL (D.HH:MM:SS)")
-		}
+	if _, err := common.ParseTimeToLive(buffersConfig.SoftDeletedLifetime); err != nil {
+		validationError(success, "The `api.buffers.softDeletedLifetime` field be a valid TTL (D.HH:MM:SS)")
 	}
 }
 

--- a/cli/internal/install/dockerinstall/validation.go
+++ b/cli/internal/install/dockerinstall/validation.go
@@ -159,23 +159,22 @@ func (inst *Installer) QuickValidateConfig() bool {
 	}
 
 	if inst.Config.Buffers == nil {
-		validationError(&success, "The `buffers` field is required")
-	} else {
-		buffersConfig := inst.Config.Buffers
-		if buffersConfig.ActiveLifetime == "" {
-			buffersConfig.ActiveLifetime = "0.00:00"
-		}
-		if buffersConfig.SoftDeletedLifetime == "" {
-			buffersConfig.SoftDeletedLifetime = "0.00:00"
-		}
+		inst.Config.Buffers = &BuffersConfig{}
+	}
+	buffersConfig := inst.Config.Buffers
+	if buffersConfig.ActiveLifetime == "" {
+		buffersConfig.ActiveLifetime = "0.00:00"
+	}
+	if buffersConfig.SoftDeletedLifetime == "" {
+		buffersConfig.SoftDeletedLifetime = "1.00:00"
+	}
 
-		if _, err := common.ParseTimeToLive(buffersConfig.ActiveLifetime); err != nil {
-			validationError(&success, "The `buffers.activeLifetime` field must be a valid TTL (D.HH:MM:SS)")
-		}
+	if _, err := common.ParseTimeToLive(buffersConfig.ActiveLifetime); err != nil {
+		validationError(&success, "The `buffers.activeLifetime` field must be a valid TTL (D.HH:MM:SS)")
+	}
 
-		if _, err := common.ParseTimeToLive(buffersConfig.SoftDeletedLifetime); err != nil {
-			validationError(&success, "The `buffers.softDeletedLifetime` field must be a valid TTL (D.HH:MM:SS)")
-		}
+	if _, err := common.ParseTimeToLive(buffersConfig.SoftDeletedLifetime); err != nil {
+		validationError(&success, "The `buffers.softDeletedLifetime` field must be a valid TTL (D.HH:MM:SS)")
 	}
 
 	return success


### PR DESCRIPTION
Bug fix: The new `buffers` config for specifying TTLs was made required, which broke the upgrade process for users of Tyger v0.9.2 and older.