### PR TITLE
Handle missing config sections during database migration

### DIFF
--- a/cli/internal/install/cloudinstall/migrations.go
+++ b/cli/internal/install/cloudinstall/migrations.go
@@ -35,6 +35,13 @@ func runWithMinimalTygerInstallation[T any](ctx context.Context, inst *Installer
 	}
 
 	if installationRevision == 0 {
+		if inst.Config.Api.Helm.Tyger == nil {
+			inst.Config.Api.Helm.Tyger = &HelmChartConfig{}
+		}
+		if inst.Config.Api.Helm.Tyger.Values == nil {
+			inst.Config.Api.Helm.Tyger.Values = map[string]any{}
+		}
+
 		inst.Config.Api.Helm.Tyger.Values["onlyMigrationDependencies"] = true
 		_, _, err = inst.InstallTygerHelmChart(ctx, false)
 		if err != nil {

--- a/cli/internal/install/cloudinstall/validation.go
+++ b/cli/internal/install/cloudinstall/validation.go
@@ -385,6 +385,10 @@ func (inst *Installer) quickValidateApiConfig(success *bool) {
 	if _, err := common.ParseTimeToLive(buffersConfig.SoftDeletedLifetime); err != nil {
 		validationError(success, "The `api.buffers.softDeletedLifetime` field be a valid TTL (D.HH:MM:SS)")
 	}
+
+	if apiConfig.Helm == nil {
+		apiConfig.Helm = &HelmConfig{}
+	}
 }
 
 func validationError(success *bool, format string, args ...any) {

--- a/cli/internal/install/cloudinstall/validation.go
+++ b/cli/internal/install/cloudinstall/validation.go
@@ -383,7 +383,7 @@ func (inst *Installer) quickValidateApiConfig(success *bool) {
 	}
 
 	if _, err := common.ParseTimeToLive(buffersConfig.SoftDeletedLifetime); err != nil {
-		validationError(success, "The `api.buffers.softDeletedLifetime` field be a valid TTL (D.HH:MM:SS)")
+		validationError(success, "The `api.buffers.softDeletedLifetime` field must be a valid TTL (D.HH:MM:SS)")
 	}
 
 	if apiConfig.Helm == nil {


### PR DESCRIPTION
The CLI would fail if `api.helm.tyger.values` was nil in the config file.