### PR TITLE
Fix regression when not using custom TLS certificate

### DIFF
--- a/cli/internal/install/cloudinstall/cloud.go
+++ b/cli/internal/install/cloudinstall/cloud.go
@@ -456,8 +456,10 @@ func (inst *Installer) createSharedPromises(ctx context.Context) install.Promise
 			return nil, fmt.Errorf("failed to create traefik namespace: %w", err)
 		}
 
-		if err := inst.addSecretProviderClass(ctx, TraefikNamespace, traefikKeyVaultClientManagedIdentityPromise, getAdminCredsPromise); err != nil {
-			return nil, err
+		if traefikKeyVaultClientManagedIdentityPromise != nil {
+			if err := inst.addSecretProviderClass(ctx, TraefikNamespace, traefikKeyVaultClientManagedIdentityPromise, getAdminCredsPromise); err != nil {
+				return nil, err
+			}
 		}
 
 		return inst.installTraefik(ctx, getAdminCredsPromise, traefikKeyVaultClientManagedIdentityPromise)

--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -146,7 +146,7 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 		}
 	}
 
-	if inst.Config.Cloud.TlsCertificate.KeyVault != nil {
+	if inst.Config.Cloud.TlsCertificate != nil && inst.Config.Cloud.TlsCertificate.KeyVault != nil {
 		if cluster.Properties.AddonProfiles == nil {
 			cluster.Properties.AddonProfiles = make(map[string]*armcontainerservice.ManagedClusterAddonProfile)
 		}


### PR DESCRIPTION
Follow-up to #212. The test environments have an organization that uses a custom TLS certificate and one that uses Let's Encrypt, but the installer fails for environments that do not have a TLS certificate.