### PR TITLE
Support storage account DNS endpoints

### DIFF
--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -166,9 +166,10 @@ type NetworkSecurityPerimeterProfileConfig struct {
 }
 
 type StorageAccountConfig struct {
-	Name     string `json:"name"`
-	Location string `json:"location"`
-	Sku      string `json:"sku"`
+	Name            string `json:"name"`
+	Location        string `json:"location"`
+	Sku             string `json:"sku"`
+	DnsEndpointType string `json:"dnsEndpointType"`
 }
 
 type DatabaseServerConfig struct {

--- a/cli/internal/install/cloudinstall/config-pretty.tpl
+++ b/cli/internal/install/cloudinstall/config-pretty.tpl
@@ -204,6 +204,8 @@ organizations:
           - name: {{ .Name }}
             {{ optionalField "location" .Location "defaults to defaultLocation" }}
             {{ optionalField "sku" .Sku "defaults to Standard_LRS" }}
+            # dnsEndpointType can be set to `AzureDNSZone` when creating large number of accounts in a single subscription.
+            {{ optionalField "dnsEndpointType" .DnsEndpointType "defaults to Standard." }}
           {{- end }}
 
         # The storage account where run logs will be stored.
@@ -211,6 +213,8 @@ organizations:
           name: {{ .Storage.Logs.Name }}
           {{ optionalField "location" .Storage.Logs.Location "defaults to defaultLocation" }}
           {{ optionalField "sku" .Storage.Logs.Sku "defaults to Standard_LRS" }}
+          # dnsEndpointType can be set to `AzureDNSZone` when creating large number of accounts in a single subscription.
+          {{ optionalField "dnsEndpointType" .Storage.Logs.DnsEndpointType "defaults to Standard." }}
 
       # An optional array of managed identities that will be created in the resource group.
       # These identities are available to runs as workload identities. When updating this list

--- a/cli/internal/install/cloudinstall/storage.go
+++ b/cli/internal/install/cloudinstall/storage.go
@@ -52,6 +52,7 @@ func (inst *Installer) CreateStorageAccount(ctx context.Context,
 			AllowSharedKeyAccess:   Ptr(false),
 			EnableHTTPSTrafficOnly: Ptr(true),
 			MinimumTLSVersion:      Ptr(armstorage.MinimumTLSVersionTLS12),
+			DNSEndpointType:        Ptr(armstorage.DNSEndpointType(storageAccountConfig.DnsEndpointType)),
 		},
 	}
 

--- a/cli/internal/install/cloudinstall/validation.go
+++ b/cli/internal/install/cloudinstall/validation.go
@@ -391,6 +391,21 @@ func quickValidateStorageAccountConfig(ctx context.Context, success *bool, cloud
 			validationError(ctx, success, "The `%s.sku` field must be one of %v for organization '%s'", path, armstorage.PossibleSKUNameValues(), orgConfig.Name)
 		}
 	}
+
+	if storageConfig.DnsEndpointType == "" {
+		storageConfig.DnsEndpointType = string(armstorage.DNSEndpointTypeStandard)
+	} else {
+		match := false
+		for _, at := range armstorage.PossibleDNSEndpointTypeValues() {
+			if storageConfig.DnsEndpointType == string(at) {
+				match = true
+				break
+			}
+		}
+		if !match {
+			validationError(ctx, success, "The `%s.dnsEndpointType` field must be one of %v for organization '%s'", path, armstorage.PossibleDNSEndpointTypeValues(), orgConfig.Name)
+		}
+	}
 }
 
 func quickValidateOrganizationConfig(ctx context.Context, success *bool, config *CloudEnvironmentConfig, org *OrganizationConfig) {

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -72,9 +72,12 @@ organizations:
       storage:
         buffers:
           - name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}lamnabuf
+            dnsEndpointType: AzureDnsZone
           - name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}lamnabuf2
+            dnsEndpointType: AzureDnsZone
           - name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}lamnabuf3
             location: ${TYGER_SECONDARY_LOCATION}
+            dnsEndpointType: AzureDnsZone
         logs:
           name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}lamnalog
 


### PR DESCRIPTION
Add support for [DNS zone endpoints](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#azure-dns-zone-endpoints-preview) for storage accounts. This feature allows a subscription to have up to 5000 storage accounts.