### PR TITLE
Clean up config and access-control command flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ include Makefile.docker
 endif
 
 get-config:
-	echo '${ENVIRONMENT_CONFIG_JSON}' | yq -P
+	./scripts/get-config.sh
 
 pretty-print-config-templates: install-cli
 	scripts/get-config.sh --pretty-print-template

--- a/cli/internal/cmd/install/cloud.go
+++ b/cli/internal/cmd/install/cloud.go
@@ -106,9 +106,9 @@ func addCommonFlags(cmd *cobra.Command, flags *commonFlags) {
 		cmd.MarkFlagRequired("file")
 	}
 	if flags.singleOrg != nil {
-		cmd.Flags().StringVarP(flags.singleOrg, "org", "o", "", "the organization this command will affect")
+		cmd.Flags().StringVar(flags.singleOrg, "org", "", "the organization this command will affect")
 	} else if flags.multiOrg != nil {
-		cmd.Flags().StringArrayVarP(flags.multiOrg, "org", "o", nil, "restrict this command to the specified organizations")
+		cmd.Flags().StringArrayVar(flags.multiOrg, "org", nil, "restrict this command to the specified organizations")
 	} else {
 		panic("either singleOrg or multiOrg must be set")
 	}

--- a/scripts/get-config.sh
+++ b/scripts/get-config.sh
@@ -169,4 +169,11 @@ if [[ "$pretty_print_template" == true ]]; then
   exit
 fi
 
-envsubst <"${config_path}" | yq eval -e "${expression}" -o "${format}" -
+rendered_config=$(envsubst <"${config_path}")
+
+if [[ "${format}" == "yaml" && "${expression}" == "." ]]; then
+  echo "${rendered_config}"
+  exit
+fi
+
+echo "${rendered_config}" | yq eval -e "${expression}" -o "${format}" -


### PR DESCRIPTION
- For `tyger access-control init` and `tyger access-control show`, we now take a `-f` flag and write to a file, otherwise stdout.
- For pretty-print commands, `-f` is a shorthand for `-i` and `-o` being the same file. If you specify `-i` without `-o` we write to stdout.
- Remove `-o` as a shorthand for `--org` across the board to avoid confusion.  