### PR TITLE
Fix user login regression

### DIFF
--- a/cli/internal/controlplane/login.go
+++ b/cli/internal/controlplane/login.go
@@ -500,13 +500,13 @@ func (c *serviceInfo) GetAccessToken(ctx context.Context) (string, error) {
 			}
 
 			if clientId == c.ClientAppUri {
-				customHttpClient := &clientIdReplacingHttpClient{
+				cachedClientId := &clientIdReplacingHttpClient{
 					clientAppUri: c.ClientAppUri,
 					clientAppId:  c.ClientId,
 					innerClient:  http.DefaultClient,
 				}
 
-				options = append(options, public.WithHTTPClient(customHttpClient))
+				options = append(options, public.WithHTTPClient(cachedClientId))
 			}
 
 			// fall back to using the refresh token from the cache


### PR DESCRIPTION
After the access token expires, we fail to use the refresh token and the user has to login again. This only applies to logins for users.

In #221, we switched to using the client ID instead of the client identifier URI to login (if it is known). Because of this, we need to look up in the MSAL cache using the client ID instead of the URI.  We still need to use the URI in cases where original login was done on either an earlier client version or an earlier server version.