### PR TITLE
Give a grace period for image pull errors

### DIFF
--- a/server/ControlPlane/Compute/Kubernetes/KubernetesMetadata.cs
+++ b/server/ControlPlane/Compute/Kubernetes/KubernetesMetadata.cs
@@ -15,6 +15,9 @@ public static partial class KubernetesMetadata
     public const string JobReplicaCountAnnotation = "tyger-job-replica-count";
     public const string WorkerReplicaCountAnnotation = "tyger-worker-replica-count";
 
+    public const string MainContainerName = "main";
+    public const string ImagePullInitContainerName = "imagepull";
+
     public static string JobPodName(long id, int index) => $"run-{id}-job-{index}";
     public static string WorkerPodName(long id, int index) => $"run-{id}-worker-{index}";
     public static string JobNameFromRunId(long id) => $"run-{id}-job";

--- a/server/ControlPlane/Compute/Kubernetes/KubernetesRunCreator.cs
+++ b/server/ControlPlane/Compute/Kubernetes/KubernetesRunCreator.cs
@@ -317,7 +317,7 @@ public class KubernetesRunCreator : RunCreatorBase, IRunCreator, ICapabilitiesCo
         initContainers.Add(
             new()
             {
-                Name = "imagepull",
+                Name = ImagePullInitContainerName,
                 Image = GetMainContainer(jobPod.Spec).Image,
                 Command = s_waitForWorkerCommand,
                 VolumeMounts = [new("/no-op/", "no-op")]
@@ -451,7 +451,7 @@ public class KubernetesRunCreator : RunCreatorBase, IRunCreator, ICapabilitiesCo
                     "--pod",
                     "$(POD_NAME)",
                     "--container",
-                    "main",
+                    MainContainerName,
                     "--log-format",
                     "json",
                 ],
@@ -494,7 +494,7 @@ public class KubernetesRunCreator : RunCreatorBase, IRunCreator, ICapabilitiesCo
                         "--pod",
                         "$(POD_NAME)",
                         "--container",
-                        "main",
+                        MainContainerName,
                         "--log-format",
                         "json",
                     ],
@@ -568,7 +568,7 @@ public class KubernetesRunCreator : RunCreatorBase, IRunCreator, ICapabilitiesCo
         return true;
     }
 
-    private static V1Container GetMainContainer(V1PodSpec podSpec) => podSpec.Containers.Single(c => c.Name == "main");
+    private static V1Container GetMainContainer(V1PodSpec podSpec) => podSpec.Containers.Single(c => c.Name == MainContainerName);
 
     private ClusterOptions GetTargetCluster(Run newRun)
     {
@@ -640,7 +640,7 @@ public class KubernetesRunCreator : RunCreatorBase, IRunCreator, ICapabilitiesCo
                 [
                     new()
                     {
-                        Name = "main",
+                        Name = MainContainerName,
                         Image = codespec.Image,
                         Command = codespec.Command?.ToArray(),
                         Args = codespec.Args?.ToArray(),

--- a/server/ControlPlane/Compute/Kubernetes/KubernetesRunLogReader.cs
+++ b/server/ControlPlane/Compute/Kubernetes/KubernetesRunLogReader.cs
@@ -76,7 +76,7 @@ public class KubernetesRunLogReader : ILogSource
 
         void TrackPipelineIfNeedsTermination(V1Pod pod, string containerName, Pipeline podPipeline)
         {
-            if (pod.GetLabel(WorkerLabel) != null || (pod.GetLabel(JobLabel) != null && containerName == "main" && pod.GetAnnotation(HasSocketAnnotation) == "true"))
+            if (pod.GetLabel(WorkerLabel) != null || (pod.GetLabel(JobLabel) != null && containerName == MainContainerName && pod.GetAnnotation(HasSocketAnnotation) == "true"))
             {
                 var terminableElement = new TerminablePipelineElement();
                 terminablePipelineElements.Add(terminableElement);


### PR DESCRIPTION
This change introduces some tolerance for transient image pull errors.  System images are given a longer grace period than user images. If the error is pull throttling, we allow retries to continue.