### PR TITLE
Handle `default` organization name

### DIFF
--- a/cli/internal/cmd/install/cloud.go
+++ b/cli/internal/cmd/install/cloud.go
@@ -6,6 +6,7 @@ package install
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/microsoft/tyger/cli/internal/install"
 	"github.com/microsoft/tyger/cli/internal/install/cloudinstall"
@@ -65,7 +66,7 @@ func newCloudUninstallCommand() *cobra.Command {
 	flags := newMultiOrgFlags()
 	all := false
 	cmd := cobra.Command{
-		Use:                   "uninstall -f CONFIG.yml",
+		Use:                   "uninstall -f CONFIG.yml [--all]",
 		Short:                 "Uninstall cloud infrastructure",
 		Long:                  "Uninstall cloud infrastructure",
 		DisableFlagsInUseLine: true,
@@ -78,6 +79,15 @@ func newCloudUninstallCommand() *cobra.Command {
 					if org.SingleOrganizationCompatibilityMode {
 						log.Fatal().Msgf("The '%s' organization is in single-organization compatibility mode and cannot be uninstalled individually. The entire environment must be removed using the --all flag.", org.Name)
 					}
+				}
+
+				if len(*flags.multiOrg) == 0 {
+					allOrgs := []string{}
+					for _, org := range cloudInstaller.Config.Organizations {
+						allOrgs = append(allOrgs, "--org", org.Name)
+					}
+
+					log.Fatal().Msgf("Specify `--all` to remove the entire cloud infrastructure, or `%s` to remove organizations but preserve shared infrastructure", strings.Join(allOrgs, " "))
 				}
 			}
 

--- a/cli/internal/install/cloudinstall/cloud.go
+++ b/cli/internal/install/cloudinstall/cloud.go
@@ -161,8 +161,15 @@ func (inst *Installer) UninstallOrganization(ctx context.Context, org *Organizat
 		return fmt.Errorf("failed to get admin REST config: %w", err)
 	}
 
-	if err := deleteKubernetesNamespace(ctx, adminRestConfig, org.Cloud.KubernetesNamespace); err != nil {
-		return fmt.Errorf("failed to delete kubernetes namespace: %w", err)
+	if org.Cloud.KubernetesNamespace == "default" {
+		// we cannot delete the default namespace, so we need to uninstall Tyger instead
+		if err := inst.uninstallTygerSingleOrg(ctx, nil, org); err != nil {
+			return fmt.Errorf("failed to uninstall Tyger: %w", err)
+		}
+	} else {
+		if err := deleteKubernetesNamespace(ctx, adminRestConfig, org.Cloud.KubernetesNamespace); err != nil {
+			return fmt.Errorf("failed to delete kubernetes namespace: %w", err)
+		}
 	}
 
 	if _, err := inst.deleteDatabase(ctx, org); err != nil {

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -305,7 +305,8 @@ type ConfigTemplateValues struct {
 	BufferStorageAccountName string
 	LogsStorageAccountName   string
 	DomainName               string
-	ApiTenantId              string
+	OrganizationTenantId     string
+	OrganizationName         string
 	CpuNodePoolMinCount      int32
 	GpuNodePoolMinCount      int32
 }
@@ -357,7 +358,7 @@ func RenderConfig(templateValues ConfigTemplateValues, writer io.Writer) error {
 		},
 		Organizations: []*OrganizationConfig{
 			{
-				Name: "default",
+				Name: templateValues.OrganizationName,
 				Cloud: &OrganizationCloudConfig{
 					Storage: &OrganizationStorageConfig{
 						Buffers: []*StorageAccountConfig{
@@ -374,7 +375,7 @@ func RenderConfig(templateValues ConfigTemplateValues, writer io.Writer) error {
 					DomainName:             templateValues.DomainName,
 					TlsCertificateProvider: TlsCertificateProviderLetsEncrypt,
 					AccessControl: &AccessControlConfig{
-						TenantID:  templateValues.ApiTenantId,
+						TenantID:  templateValues.OrganizationTenantId,
 						ApiAppUri: "api://tyger-server",
 						CliAppUri: "api://tyger-cli",
 						RoleAssignments: &TygerRbacRoleAssignments{

--- a/cli/internal/install/cloudinstall/cloudconfig_test.go
+++ b/cli/internal/install/cloudinstall/cloudconfig_test.go
@@ -37,6 +37,7 @@ func TestRenderConfig(t *testing.T) {
 		DomainName:               "me.westus.cloudapp.azure.com",
 		DatabaseServerName:       "dbserver",
 		OrganizationTenantId:     "tenant2",
+		OrganizationName:         "myorg",
 	}
 
 	var buf bytes.Buffer
@@ -71,4 +72,5 @@ func TestRenderConfig(t *testing.T) {
 	require.Equal(t, values.LogsStorageAccountName, config.Organizations[0].Cloud.Storage.Logs.Name)
 	require.Equal(t, values.DomainName, config.Organizations[0].Api.DomainName)
 	require.Equal(t, values.OrganizationTenantId, config.Organizations[0].Api.AccessControl.TenantID)
+	require.Equal(t, values.OrganizationName, config.Organizations[0].Name)
 }

--- a/cli/internal/install/cloudinstall/cloudconfig_test.go
+++ b/cli/internal/install/cloudinstall/cloudconfig_test.go
@@ -36,7 +36,7 @@ func TestRenderConfig(t *testing.T) {
 		LogsStorageAccountName:   "acc2",
 		DomainName:               "me.westus.cloudapp.azure.com",
 		DatabaseServerName:       "dbserver",
-		ApiTenantId:              "tenant2",
+		OrganizationTenantId:     "tenant2",
 	}
 
 	var buf bytes.Buffer
@@ -70,5 +70,5 @@ func TestRenderConfig(t *testing.T) {
 	require.Equal(t, values.BufferStorageAccountName, config.Organizations[0].Cloud.Storage.Buffers[0].Name)
 	require.Equal(t, values.LogsStorageAccountName, config.Organizations[0].Cloud.Storage.Logs.Name)
 	require.Equal(t, values.DomainName, config.Organizations[0].Api.DomainName)
-	require.Equal(t, values.ApiTenantId, config.Organizations[0].Api.AccessControl.TenantID)
+	require.Equal(t, values.OrganizationTenantId, config.Organizations[0].Api.AccessControl.TenantID)
 }

--- a/cli/internal/install/cloudinstall/validation.go
+++ b/cli/internal/install/cloudinstall/validation.go
@@ -29,6 +29,7 @@ var (
 	ResourceNameRegex         = regexp.MustCompile(`^[a-z][a-z\-0-9]{2,23}$`)
 	StorageAccountNameRegex   = regexp.MustCompile(`^[a-z0-9]{3,24}$`)
 	SubdomainRegex            = regexp.MustCompile(`^[a-zA-Z]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$`)
+	OrganizationNameRegex     = regexp.MustCompile(`^[a-z]([a-z0-9\-]{0,61}[a-z0-9])?$`)
 	DatabaseServerNameRegex   = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-]{1,61}[a-z0-9])?$`)
 	reservedOrganizationNames = []string{"postgres"}
 )
@@ -385,8 +386,8 @@ func quickValidateOrganizationConfig(ctx context.Context, success *bool, config 
 
 	if org.Name == "" {
 		validationError(ctx, success, "The `organization.name` field is required")
-	} else if !SubdomainRegex.MatchString(org.Name) {
-		validationError(ctx, success, "The `organization.name` field must match the pattern %s", SubdomainRegex)
+	} else if !OrganizationNameRegex.MatchString(org.Name) {
+		validationError(ctx, success, "The `organization.name` field must match the pattern %s", OrganizationNameRegex)
 	} else if slices.ContainsFunc(reservedOrganizationNames, func(name string) bool { return strings.EqualFold(name, org.Name) }) {
 		validationError(ctx, success, "The `organization.name` field cannot be %s", org.Name)
 	}

--- a/docs/introduction/installation/cloud-installation.md
+++ b/docs/introduction/installation/cloud-installation.md
@@ -400,7 +400,7 @@ Note: This does **not** delete any database data or buffers.
 To uninstall all cloud resources, run:
 
 ```bash
-tyger cloud uninstall -f config.yml
+tyger cloud uninstall -f config.yml --all
 ```
 
 ::: danger Warning


### PR DESCRIPTION
The Kubernetes namespace corresponds to the organization name. If it is named `default` we cannot delete the namespace, and instead must remove all Tyger-related Kubernetes object.

The `tyger config create` command created an organization with this name. The wizard now lets you customize the name and makes a suggestion based on the Entra tenant's domain.