### PR TITLE
Support Subject Name and Issuer authentication

### DIFF
--- a/cli/internal/controlplane/login.go
+++ b/cli/internal/controlplane/login.go
@@ -960,7 +960,7 @@ func (si *serviceInfo) performServicePrincipalLogin(ctx context.Context) (Access
 			return AccessToken{}, fmt.Errorf("error creating credential: %w", err)
 		}
 
-		client, err := confidential.New(si.Authority, si.Principal, cred, confidential.WithHTTPClient(client.DefaultClient.StandardClient()))
+		client, err := confidential.New(si.Authority, si.Principal, cred, confidential.WithHTTPClient(client.DefaultClient.StandardClient()), confidential.WithX5C())
 		if err != nil {
 			return AccessToken{}, err
 		}


### PR DESCRIPTION
Send the [`x5c`](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.6) header when using a certificate to log in, to support Subject Name and Issuer (SNI) authentication. This avoids certificate pinning.