### PR TITLE
Preserve client IP addresses in Traefik logs

### DIFF
--- a/cli/internal/install/cloudinstall/helm.go
+++ b/cli/internal/install/cloudinstall/helm.go
@@ -83,6 +83,9 @@ func (inst *Installer) installTraefik(ctx context.Context, restConfigPromise *in
 				"annotations": map[string]any{
 					"service.beta.kubernetes.io/azure-dns-label-name": inst.Config.Cloud.Compute.DnsLabel,
 				},
+				"spec": map[string]any{
+					"externalTrafficPolicy": "Local", // in order to preserve client IP addresses
+				},
 			},
 			"additionalArguments": []string{
 				"--entryPoints.websecure.http.tls=true",


### PR DESCRIPTION
Because `externalTrafficPolicy` was set to the default value of `Cluster` on the Traefik service, the load balancer forwarded traffic to kube-proxy, which forwarded to the Traefik pod. This meant that the client IP address in the Traefix logs was always the AKS node's IP.