### PR TITLE
Fix buffer transfer metrics bug

### DIFF
--- a/cli/cmd/buffer-copier/export.go
+++ b/cli/cmd/buffer-copier/export.go
@@ -104,7 +104,7 @@ func newExportCommand(dbFlags *databaseFlags) *cobra.Command {
 						if err := copyBuffer(ctx, bufferIdAndTags, sourceBlobServiceClient, destBlobServiceClient, transferMetrics, sema, bufferIdTransform); err != nil {
 							cancel(err)
 						} else {
-							transferMetrics.Update(0, 1)
+							transferMetrics.UpdateCompleted(0, 1)
 						}
 						overallWg.Done()
 					}
@@ -119,6 +119,7 @@ func newExportCommand(dbFlags *databaseFlags) *cobra.Command {
 
 				for _, bufferIdAndTags := range page {
 					overallWg.Add(1)
+					transferMetrics.EnsureStarted(nil)
 					bufferChannel <- bufferIdAndTags
 				}
 			}
@@ -234,7 +235,7 @@ func copyBuffer(ctx context.Context,
 					break
 				}
 
-				transferMetrics.Update(uint64(*blob.Properties.ContentLength), 0)
+				transferMetrics.UpdateCompleted(uint64(*blob.Properties.ContentLength), 0)
 			}()
 		}
 	}

--- a/cli/internal/dataplane/relayclient.go
+++ b/cli/internal/dataplane/relayclient.go
@@ -227,7 +227,8 @@ type ReaderWithMetrics struct {
 func (c *ReaderWithMetrics) Read(p []byte) (n int, err error) {
 	n, err = c.reader.Read(p)
 	if n > 0 {
-		c.transferMetrics.Update(uint64(n), 0)
+		c.transferMetrics.EnsureStarted(nil)
+		c.transferMetrics.UpdateCompleted(uint64(n), 0)
 	}
 	return n, err
 }

--- a/cli/internal/dataplane/transfermetrics.go
+++ b/cli/internal/dataplane/transfermetrics.go
@@ -4,9 +4,12 @@
 package dataplane
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -16,13 +19,15 @@ import (
 
 type TransferMetrics struct {
 	ctx                context.Context
+	started            atomic.Bool
 	totalBuffers       atomic.Uint64
-	totalBytes         uint64
+	totalBytes         atomic.Uint64
 	currentPeriodBytes atomic.Uint64
 	startTime          time.Time
 	ticker             *time.Ticker
 	stoppedChannel     chan any
 	reportingComplete  chan any
+	mut                sync.Mutex
 }
 
 func NewTransferMetrics(ctx context.Context) *TransferMetrics {
@@ -31,22 +36,49 @@ func NewTransferMetrics(ctx context.Context) *TransferMetrics {
 	}
 }
 
-func (ts *TransferMetrics) Update(byteCount uint64, completedBuffers uint64) {
-	newPeriodBytes := ts.currentPeriodBytes.Add(byteCount)
-	newCompletedBuffers := ts.totalBuffers.Add(completedBuffers)
-
-	if (byteCount > 0 && newPeriodBytes == byteCount || completedBuffers > 0 && newCompletedBuffers == completedBuffers) && ts.startTime == (time.Time{}) {
-		ts.start()
-	}
+// Called when a buffer or buffer have been completely transferred
+func (ts *TransferMetrics) UpdateCompleted(byteCount uint64, completedBuffers uint64) {
+	ts.totalBytes.Add(byteCount)
+	ts.totalBuffers.Add(completedBuffers)
 }
 
-func (ts *TransferMetrics) start() {
+// Called when data HTTP body is being read or written.
+// Note that because of retries, this
+func (ts *TransferMetrics) UpdateInFlight(byteCount uint64) {
+	ts.currentPeriodBytes.Add(byteCount)
+}
+
+func (ts *TransferMetrics) EnsureStarted(startTime *time.Time) {
+	if ts.started.Swap(true) {
+		if startTime != nil {
+			// Update the start time if it is earlier than the current one.
+			// This can happen when that was downloaded was started before a one that completed first.
+			ts.mut.Lock()
+			defer ts.mut.Unlock()
+			if startTime.Before(ts.startTime) {
+				ts.startTime = *startTime
+			}
+
+			ts.startTime = *startTime
+		}
+		return
+	}
+
 	ts.stoppedChannel = make(chan any)
 	ts.reportingComplete = make(chan any)
-	ts.ticker = time.NewTicker(2 * time.Second)
 	lastTime := time.Now()
-	ts.startTime = lastTime
+	ts.mut.Lock()
+	defer ts.mut.Unlock()
+	if startTime != nil {
+		ts.startTime = *startTime
+	} else {
+		ts.startTime = lastTime
+	}
+
+	ts.ticker = time.NewTicker(time.Second)
 	go func() {
+		lastBytesPerSecond := uint64(0)
+		lastTotaBytes := uint64(0)
 		for {
 			select {
 			case <-ts.stoppedChannel:
@@ -59,8 +91,16 @@ func (ts *TransferMetrics) start() {
 				elapsed := currentTime.Sub(lastTime)
 				lastTime = currentTime
 				currentBytes := ts.currentPeriodBytes.Swap(0)
-				ts.totalBytes += currentBytes
 				bytesPerSecond := uint64(float64(currentBytes) / elapsed.Seconds())
+				totalBytesSnapshot := ts.totalBytes.Load()
+				if bytesPerSecond == 0 && lastBytesPerSecond == 0 && totalBytesSnapshot == lastTotaBytes {
+					// No change in bytes per second or total bytes, and we logged 0 thoughput last time.
+					continue
+				}
+
+				lastTotaBytes = totalBytesSnapshot
+				lastBytesPerSecond = bytesPerSecond
+
 				// For networking throughput in Mbps, we divide by 1000 * 1000 (not 1024 * 1024) because
 				// networking is traditionally done in base 10 units (not base 2).
 				partial := log.Ctx(ts.ctx).Info().Str("throughput", fmt.Sprintf("%sps", humanizeBytesAsBits(bytesPerSecond)))
@@ -69,7 +109,7 @@ func (ts *TransferMetrics) start() {
 					partial = partial.Str("totalBuffers", humanize.Comma(int64(totalBuffers)))
 				}
 
-				partial = partial.Str("totalData", removeSpaces(humanize.IBytes(ts.totalBytes)))
+				partial = partial.Str("totalCompletedData", removeSpaces(humanize.IBytes(totalBytesSnapshot)))
 
 				partial.Msg("Transfer progress")
 			}
@@ -85,10 +125,9 @@ func (ts *TransferMetrics) Stop() {
 		elapsed = time.Since(ts.startTime)
 		ts.stoppedChannel <- nil
 		<-ts.reportingComplete
-		ts.totalBytes += ts.currentPeriodBytes.Load()
 	}
 
-	bytesPerSecond := uint64(float64(ts.totalBytes) / elapsed.Seconds())
+	bytesPerSecond := uint64(float64(ts.totalBytes.Load()) / elapsed.Seconds())
 
 	partial := log.Ctx(ts.ctx).Info().
 		Str("elapsed", elapsed.Round(time.Second).String()).
@@ -99,7 +138,7 @@ func (ts *TransferMetrics) Stop() {
 		partial = partial.Uint64("totalBuffers", totalBuffers)
 	}
 
-	partial = partial.Str("totalData", removeSpaces(humanize.IBytes(ts.totalBytes)))
+	partial = partial.Str("totalCompletedData", removeSpaces(humanize.IBytes(ts.totalBytes.Load())))
 	partial.Msg("Transfer complete")
 }
 
@@ -111,4 +150,41 @@ func humanizeBytesAsBits(bytes uint64) string {
 // "1 MB" -> "1MB" to that log field values are not quoted in the console
 func removeSpaces(s string) string {
 	return strings.Replace(s, " ", "", -1)
+}
+
+type DownloadProgressReader struct {
+	Reader          io.ReadCloser
+	TransferMetrics *TransferMetrics
+}
+
+func (pr *DownloadProgressReader) Read(p []byte) (int, error) {
+	n, err := pr.Reader.Read(p)
+	if n > 0 {
+		pr.TransferMetrics.UpdateInFlight(uint64(n))
+	}
+
+	return n, err
+}
+
+func (pr *DownloadProgressReader) Close() error {
+	return pr.Reader.Close()
+}
+
+type UploadProgressReader struct {
+	Reader          *bytes.Reader
+	TransferMetrics *TransferMetrics
+}
+
+func (pr *UploadProgressReader) Read(p []byte) (int, error) {
+	n, err := pr.Reader.Read(p)
+	if n > 0 {
+		pr.TransferMetrics.UpdateInFlight(uint64(n))
+	}
+
+	return n, err
+}
+
+// Implement retryablehttp.LenReader
+func (ts *UploadProgressReader) Len() int {
+	return int(ts.Reader.Size())
 }

--- a/cli/internal/dataplane/write.go
+++ b/cli/internal/dataplane/write.go
@@ -4,6 +4,7 @@
 package dataplane
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5"
 	"crypto/sha256"
@@ -139,14 +140,22 @@ func Write(ctx context.Context, container *Container, inputReader io.Reader, opt
 	for i := 0; i < writeOptions.dop; i++ {
 		go func() {
 			defer wg.Done()
+			firstBlobForThisGoroutine := true
 			for bb := range outputChannel {
 				ctx := log.Ctx(ctx).With().Int64("blobNumber", bb.BlobNumber).Logger().WithContext(ctx)
-				var body any = bb.Contents
+				var body any
 				if len(bb.Contents) == 0 {
 					// This is a bit subtle, but if we send an empty or nil []byte body,
 					// we will empty with the Transfer-Encoding: chunked header, which
 					// the blob service does not support.  So we send a nil body instead.
 					body = nil
+				} else {
+					body = retryablehttp.ReaderFunc(func() (io.Reader, error) {
+						return &UploadProgressReader{
+							Reader:          bytes.NewReader(bb.Contents),
+							TransferMetrics: metrics,
+						}, nil
+					})
 				}
 
 				md5Hash := md5.Sum(bb.Contents)
@@ -159,6 +168,11 @@ func Write(ctx context.Context, container *Container, inputReader io.Reader, opt
 
 				bb.CurrentCumulativeHash <- encodedHashChain
 
+				if firstBlobForThisGoroutine {
+					metrics.EnsureStarted(nil)
+					firstBlobForThisGoroutine = false
+				}
+
 				if err := uploadBlobWithRetry(ctx, httpClient, container, MakeBlobPath(bb.BlobNumber), body, encodedMD5Hash, encodedHashChain); err != nil {
 					if !errors.Is(err, ctx.Err()) {
 						log.Debug().Err(err).Msg("Encountered error uploading blob")
@@ -167,7 +181,7 @@ func Write(ctx context.Context, container *Container, inputReader io.Reader, opt
 					return
 				}
 
-				metrics.Update(uint64(len(bb.Contents)), 0)
+				metrics.UpdateCompleted(uint64(len(bb.Contents)), 0)
 
 				pool.Put(bb.Contents)
 			}


### PR DESCRIPTION
The elapsed time of `tyger buffer read` and `tyger buffer write` was incorrectly based on the start time of the first completely uploaded or downloaded blob. 
An easy repo is to run `tyger buffer write $(tyger buffer create)   --flush-interval 0 --block-size 1G --log-level trace` and notice that the `Transfer starting` message comes well after `Sending request blobNumber=0`

Also basing the throughput number on bytes read/written in-flight and not waiting for the entire blob to be completed.