### PR TITLE
Logging run metrics

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,7 +54,7 @@ RUN umask 0002 \
     && MOBY=false VERSION=27.5.1 DOCKERDASHCOMPOSEVERSION=none bash install.sh \
     # AZURE CLI
     && cd /opt/features/src/azure-cli \
-    && VERSION=2.73.0 bash install.sh \
+    && VERSION=2.75.0 bash install.sh \
     # POWERSHELL
     && cd /opt/features/src/powershell \
     && VERSION=7.3.9 bash install.sh \

--- a/.github/actions/login-azure/action.yml
+++ b/.github/actions/login-azure/action.yml
@@ -25,7 +25,7 @@ runs:
         Components: main
         Architectures: $(dpkg --print-architecture)
         Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
-        AZ_VER=2.73.0
+        AZ_VER=2.75.0
         sudo apt-get update && sudo apt-get install azure-cli=${AZ_VER}-1~${AZ_DIST}
 
     - name: downgrade Azure CLI (Linux)

--- a/server/Common/Logging/JsonFormatter.cs
+++ b/server/Common/Logging/JsonFormatter.cs
@@ -67,6 +67,11 @@ internal sealed class JsonFormatter : ConsoleFormatter
             }
         }, null);
 
+        if (Environment.GetEnvironmentVariable("ServiceMetadata__ExternalBaseUrl") is { } externalBaseUrl)
+        {
+            writer.WriteString("host", externalBaseUrl);
+        }
+
         writer.WriteString("message", message);
         if (logEntry.Exception != null)
         {

--- a/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
+++ b/server/ControlPlane/Compute/Docker/DockerRunCreator.cs
@@ -516,7 +516,7 @@ public partial class DockerRunCreator : RunCreatorBase, IRunCreator, IHostedServ
 
         await Repository.UpdateRunAsResourcesCreated(run.Id!.Value, run, cancellationToken: cancellationToken);
 
-        _logger.CreatedRun(run.Id!.Value);
+        _logger.CreatedRun(run.Id!.Value, jobCodespec.Image, jobCodespec.Resources?.Requests?.Cpu?.ToString(), jobCodespec.Resources?.Gpu?.ToString(), jobCodespec.Resources?.Requests?.Memory?.ToString());
         return run with { Status = RunStatus.Running };
     }
 

--- a/server/ControlPlane/Compute/Kubernetes/LoggerExtensions.cs
+++ b/server/ControlPlane/Compute/Kubernetes/LoggerExtensions.cs
@@ -32,8 +32,8 @@ public static partial class LoggerExtensions
     [LoggerMessage(LogLevel.Information, "Finalizing run {runId}.")]
     public static partial void FinalizingRun(this ILogger logger, long runId);
 
-    [LoggerMessage(LogLevel.Information, "Finalized run {runId}.")]
-    public static partial void FinalizedRun(this ILogger logger, long runId);
+    [LoggerMessage(LogLevel.Information, "Finalized run {runId}. Status: {status}, CreateTime: {createTime}, StartTime: {startTime}, FinishTime: {finishTime}")]
+    public static partial void FinalizedRun(this ILogger logger, long runId, string status, DateTimeOffset? createTime, DateTimeOffset? startTime, DateTimeOffset? finishTime);
 
     [LoggerMessage(LogLevel.Error, "Error finalizing run {runId}.")]
     public static partial void ErrorFinalizingRun(this ILogger logger, long runId, Exception exception);

--- a/server/ControlPlane/Compute/Kubernetes/RunFinalizer.cs
+++ b/server/ControlPlane/Compute/Kubernetes/RunFinalizer.cs
@@ -199,26 +199,14 @@ public class RunFinalizer : BackgroundService
         }
 
         await _repository.UpdateRunAsFinal(runState.Id, cancellationToken);
-        
-        // Get run data for logging
         var runResult = await _repository.GetRun(runState.Id, cancellationToken, GetRunOptions.SkipTags);
         if (runResult != null)
         {
-            _logger.FinalizedRun(
-                runState.Id, 
-                runState.Status.ToString(), 
-                runResult.Value.run.CreatedAt, 
-                runResult.Value.run.StartedAt, 
-                runResult.Value.run.FinishedAt);
+            _logger.FinalizedRun(runState.Id, runState.Status.ToString(), runResult.Value.run.CreatedAt, runResult.Value.run.StartedAt, runResult.Value.run.FinishedAt);
         }
         else
         {
-            _logger.FinalizedRun(
-                runState.Id, 
-                runState.Status.ToString(), 
-                null, 
-                null, 
-                null);
+            _logger.FinalizedRun(runState.Id, runState.Status.ToString(), null, null, null);
         }
     }
 

--- a/server/ControlPlane/Compute/Kubernetes/RunFinalizer.cs
+++ b/server/ControlPlane/Compute/Kubernetes/RunFinalizer.cs
@@ -198,16 +198,8 @@ public class RunFinalizer : BackgroundService
             }
         }
 
-        await _repository.UpdateRunAsFinal(runState.Id, cancellationToken);
-        var runResult = await _repository.GetRun(runState.Id, cancellationToken, GetRunOptions.SkipTags);
-        if (runResult != null)
-        {
-            _logger.FinalizedRun(runState.Id, runState.Status.ToString(), runResult.Value.run.CreatedAt, runResult.Value.run.StartedAt, runResult.Value.run.FinishedAt);
-        }
-        else
-        {
-            _logger.FinalizedRun(runState.Id, runState.Status.ToString(), null, null, null);
-        }
+        var (createdAt, startedAt, finishedAt) = await _repository.UpdateRunAsFinal(runState.Id, cancellationToken);
+        _logger.FinalizedRun(runState.Id, runState.Status.ToString(), createdAt, startedAt, finishedAt);
     }
 
     private async Task ArchiveLogs(long runId, CancellationToken cancellationToken)

--- a/server/ControlPlane/Compute/Kubernetes/RunFinalizer.cs
+++ b/server/ControlPlane/Compute/Kubernetes/RunFinalizer.cs
@@ -199,7 +199,27 @@ public class RunFinalizer : BackgroundService
         }
 
         await _repository.UpdateRunAsFinal(runState.Id, cancellationToken);
-        _logger.FinalizedRun(runState.Id);
+        
+        // Get run data for logging
+        var runResult = await _repository.GetRun(runState.Id, cancellationToken, GetRunOptions.SkipTags);
+        if (runResult != null)
+        {
+            _logger.FinalizedRun(
+                runState.Id, 
+                runState.Status.ToString(), 
+                runResult.Value.run.CreatedAt, 
+                runResult.Value.run.StartedAt, 
+                runResult.Value.run.FinishedAt);
+        }
+        else
+        {
+            _logger.FinalizedRun(
+                runState.Id, 
+                runState.Status.ToString(), 
+                null, 
+                null, 
+                null);
+        }
     }
 
     private async Task ArchiveLogs(long runId, CancellationToken cancellationToken)

--- a/server/ControlPlane/Compute/LoggerExtensions.cs
+++ b/server/ControlPlane/Compute/LoggerExtensions.cs
@@ -8,8 +8,8 @@ namespace Tyger.ControlPlane.Compute;
 public static partial class LoggerExtensions
 {
 
-    [LoggerMessage(LogLevel.Information, "Created new run {runId}")]
-    public static partial void CreatedRun(this ILogger logger, long runId);
+    [LoggerMessage(LogLevel.Information, "Created new run {runId}. Container: {containerImage}, CPU: {cpuRequests}, GPU: {gpuRequests}, Memory: {memRequests}")]
+    public static partial void CreatedRun(this ILogger logger, long runId, string? containerImage, string? cpuRequests, string? gpuRequests, string? memRequests);
 
     [LoggerMessage(LogLevel.Information, "Created run {runId} resources")]
     public static partial void CreatedRunResources(this ILogger logger, long runId);


### PR DESCRIPTION
This PR introduced initial logging of metrics on runs. Specifically:

on run creation, we log:
* image
* cpu requests
* gpu requests
* memory requests

on finalizing a run:
* create time
* start time
* end time
* status

We also extend the base log formatter to include the host to allow separation of log data in multi-tenant deployments.

Log Analytics queries can then we run with:

```KQL

let resoureceId = "/subscriptions/xxx/resourcegroups/xxx/providers/microsoft.containerservice/managedclusters/xxx";

let createdRuns = 
ContainerLog
| where _ResourceId == resourceId
| where LogEntry has "args"
| extend l = parse_json(LogEntry)
| where l.category startswith "Tyger.ControlPlane.Compute.Kubernetes.KubernetesRunCreator[CreatedRun]"
| project runId = toint(l.args.runId), cpuRequests = l.args.cpuRequests, memRequests = l.args.memRequests, gpuRequests = l.args.gpuRequests, containerImage = l.args.containerImage, host = l.host;

let completedRuns = 
ContainerLog
| where _ResourceId == resourceId
| where LogEntry has "args"
| extend l = parse_json(LogEntry)
| where l.category startswith "Tyger.ControlPlane.Compute.Kubernetes.RunFinalizer[FinalizedRun]"
| project runId = toint(l.args.runId), runTime = totimespan(todatetime(l.args.finishTime) - todatetime(l.args.startTime)), totalTime = totimespan(todatetime(l.args.finishTime) - todatetime(l.args.createTime)), status = l.args.status;

createdRuns
| join kind=inner completedRuns on runId
```