### PR TITLE
Private networking

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.5.0
-	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.1
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2
 	github.com/IGLOU-EU/go-wildcard/v2 v2.0.2
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/a8m/envsubst v1.4.2
@@ -63,7 +63,9 @@ require (
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7 v7.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -13,6 +13,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 h1:FPKJS1T+clwv+OLGt13a8UjqeRuh0O4SJ3lUriThc+4=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1/go.mod h1:j2chePtV91HrC22tGoRX3sGY42uF13WzmmV80/OdVAA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.8.0 h1:0nGmzwBv5ougvzfGPCO2ljFRHvun57KpNrVCMrlk0ns=
@@ -31,10 +33,14 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0/go.mod h1:jj6P8ybImR+5topJ+eH6fgcemSFBmU6/6bFF8KkwuDI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 h1:z4YeiSXxnUI+PqB46Yj6MZA3nwb1CcJIkEMDrzUd8Cs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0/go.mod h1:rko9SzMxcMk0NJsNAxALEGaTYyy79bNRwxgJfrH0Spw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7 v7.0.0 h1:qZQVUcgr3ZUsyt8lf4FS+Wjj1NxyPaMY7Nj/3UiFgO4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7 v7.0.0/go.mod h1:vbbC5kaJ8H3mz4GIXafT5thlUo2qzW46Zzl1dKKpZVk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.2.0 h1:4FlNvfcPu7tTvOgOzXxIbZLvwvmZq1OdhQUdIa9g2N4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.2.0/go.mod h1:A4nzEXwVd5pAyneR6KOvUAo72svUc5rmCzRHhAbP6lA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v4 v4.0.0-beta.5 h1:Ic1Ul5dWX60QUSvh17eBbNx4sulJBjTtzBEg8H9dWEg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v4 v4.0.0-beta.5/go.mod h1:QzfotZno3CYHLJjfCZ5fBeBvMclkwlrma8FHLA2Wets=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 h1:yzrctSl9GMIQ5lHu7jc8olOsGjWDCsBpJhWqfGa/YIM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0/go.mod h1:GE4m0rnnfwLGX0Y9A9A25Zx5N/90jneT5ABevqzhuFQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=
@@ -49,6 +55,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.1 h1:8BKxhZZLX/WosEeoCvWysmKUscfa9v8LIPEEU0JjE2o=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=

--- a/cli/internal/install/cloudinstall/accesscontrol.go
+++ b/cli/internal/install/cloudinstall/accesscontrol.go
@@ -374,9 +374,10 @@ type roleIds struct {
 func getRoleIds(serverSp *aadServicePrincipal) (roleIds, error) {
 	roleIds := roleIds{}
 	for _, role := range serverSp.AppRoles {
-		if role.Value == tygerOwnerRoleValue {
+		switch role.Value {
+		case tygerOwnerRoleValue:
 			roleIds.ownerRoleId = role.Id
-		} else if role.Value == tygerContributorRoleValue {
+		case tygerContributorRoleValue:
 			roleIds.contributorRoleId = role.Id
 		}
 	}

--- a/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
+++ b/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
@@ -68,9 +68,9 @@ cloud:
           subnetName: {{ .ExistingSubnet.SubnetName }}
         {{- else -}}
         # existingSubnet:
-          # resourceGroup:
-          # vnetName:
-          # subnetName:
+        #   resourceGroup:
+        #   vnetName:
+        #   subnetName:
         {{- end }}
 
         systemNodePool:

--- a/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
+++ b/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
@@ -8,6 +8,11 @@ cloud:
   resourceGroup: {{ .ResourceGroup }}
   defaultLocation: {{ .DefaultLocation}}
 
+  # Whether to use private networking. The default is false.
+  # If true, Tyger service, storage storage accounts, and all other created resources
+  # will not be accessible from the public internet.
+  privateNetworking: {{ .PrivateNetworking }}
+
   # Optionally point an existing Log Analytics workspace to send logs to.
   {{ if .LogAnalyticsWorkspace -}}
   logAnalyticsWorkspace:
@@ -54,6 +59,20 @@ cloud:
         kubernetesVersion: "{{ .KubernetesVersion }}"
         {{ optionalField "sku" .Sku "defaults to defaultLocation" }}
         {{ optionalField "location" .Location "defaults to Standard" }}
+
+        # An existing virtual network subnet to deploy the cluster into.
+        {{ if .ExistingSubnet -}}
+        existingSubnet:
+          resourceGroup: {{ .ExistingSubnet.ResourceGroup }}
+          vnetName: {{ .ExistingSubnet.VNetName }}
+          subnetName: {{ .ExistingSubnet.SubnetName }}
+        {{- else -}}
+        # existingSubnet:
+          # resourceGroup:
+          # vnetName:
+          # subnetName:
+        {{- end }}
+
         systemNodePool:
           name: {{ .SystemNodePool.Name }}
           vmSize: {{ .SystemNodePool.VMSize }}

--- a/cli/internal/install/cloudinstall/cloud.go
+++ b/cli/internal/install/cloudinstall/cloud.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/fatih/color"
@@ -205,6 +206,12 @@ func (inst *Installer) UninstallCloud(ctx context.Context, all bool) error {
 
 	if err != nil {
 		return err
+	}
+
+	if inst.Config.Cloud.PrivateNetworking {
+		inst.forEachVnet(ctx, func(ctx context.Context, vnet *armnetwork.VirtualNetwork, subnet *armnetwork.Subnet, configSubnet *SubnetReference) error {
+			return inst.safeDeleteResourceGroup(ctx, configSubnet.PrivateLinkResourceGroup)
+		})
 	}
 
 	for _, c := range inst.Config.Cloud.Compute.Clusters {

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -73,6 +73,7 @@ type CloudConfig struct {
 	LogAnalyticsWorkspace *NamedAzureResource   `yaml:"logAnalyticsWorkspace"`
 	DnsZone               *NamedAzureResource   `yaml:"dnsZone"`
 	TlsCertificate        *TlsCertificate       `yaml:"tlsCertificate"`
+	PrivateNetworking     bool                  `yaml:"privateNetworking"`
 
 	// Internal support for associating resources with a network security perimeter profile
 	NetworkSecurityPerimeter *NetworkSecurityPerimeterConfig `yaml:"networkSecurityPerimeter"`
@@ -164,8 +165,16 @@ type ClusterConfig struct {
 	Location          string                                    `yaml:"location"`
 	Sku               armcontainerservice.ManagedClusterSKUTier `yaml:"sku"`
 	KubernetesVersion string                                    `yaml:"kubernetesVersion,omitempty"`
+	ExistingSubnet    *SubnetReference                          `yaml:"existingSubnet,omitempty"`
 	SystemNodePool    *NodePoolConfig                           `yaml:"systemNodePool"`
 	UserNodePools     []*NodePoolConfig                         `yaml:"userNodePools"`
+}
+
+type SubnetReference struct {
+	ResourceGroup            string `yaml:"resourceGroup"`
+	VNetName                 string `yaml:"vnetName"`
+	SubnetName               string `yaml:"subnetName"`
+	PrivateLinkResourceGroup string `yaml:"-"`
 }
 
 type NodePoolConfig struct {

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -68,12 +68,12 @@ type CloudConfig struct {
 	SubscriptionID        string                `yaml:"subscriptionId"`
 	DefaultLocation       string                `yaml:"defaultLocation"`
 	ResourceGroup         string                `yaml:"resourceGroup"`
+	PrivateNetworking     bool                  `yaml:"privateNetworking"`
 	Compute               *ComputeConfig        `yaml:"compute"`
 	Database              *DatabaseServerConfig `yaml:"database"`
 	LogAnalyticsWorkspace *NamedAzureResource   `yaml:"logAnalyticsWorkspace"`
 	DnsZone               *NamedAzureResource   `yaml:"dnsZone"`
 	TlsCertificate        *TlsCertificate       `yaml:"tlsCertificate"`
-	PrivateNetworking     bool                  `yaml:"privateNetworking"`
 
 	// Internal support for associating resources with a network security perimeter profile
 	NetworkSecurityPerimeter *NetworkSecurityPerimeterConfig `yaml:"networkSecurityPerimeter"`
@@ -175,6 +175,8 @@ type SubnetReference struct {
 	VNetName                 string `yaml:"vnetName"`
 	SubnetName               string `yaml:"subnetName"`
 	PrivateLinkResourceGroup string `yaml:"-"`
+	VNetResourceId           string `yaml:"-"`
+	SubnetResourceId         string `yaml:"-"`
 }
 
 type NodePoolConfig struct {

--- a/cli/internal/install/cloudinstall/database.go
+++ b/cli/internal/install/cloudinstall/database.go
@@ -90,6 +90,13 @@ func (inst *Installer) createDatabaseServer(ctx context.Context) (any, error) {
 		geoRedundantBackup = armpostgresqlflexibleservers.GeoRedundantBackupEnumEnabled
 	}
 
+	var publicNetworkAccess *armpostgresqlflexibleservers.ServerPublicNetworkAccessState
+	if inst.Config.Cloud.PrivateNetworking {
+		publicNetworkAccess = Ptr(armpostgresqlflexibleservers.ServerPublicNetworkAccessStateDisabled)
+	} else {
+		publicNetworkAccess = Ptr(armpostgresqlflexibleservers.ServerPublicNetworkAccessStateEnabled)
+	}
+
 	serverParameters := armpostgresqlflexibleservers.Server{
 		Tags:     tags,
 		Location: &databaseConfig.Location,
@@ -108,7 +115,7 @@ func (inst *Installer) createDatabaseServer(ctx context.Context) (any, error) {
 				StorageSizeGB: Ptr(int32(*databaseConfig.StorageSizeGB)),
 			},
 			Network: &armpostgresqlflexibleservers.Network{
-				PublicNetworkAccess: Ptr(armpostgresqlflexibleservers.ServerPublicNetworkAccessStateEnabled),
+				PublicNetworkAccess: publicNetworkAccess,
 			},
 			Backup: &armpostgresqlflexibleservers.Backup{
 				BackupRetentionDays: Ptr(int32(*databaseConfig.BackupRetentionDays)),
@@ -193,89 +200,95 @@ func (inst *Installer) createDatabaseServer(ctx context.Context) (any, error) {
 		}
 	}
 
-	desiredFirewallRules := map[string]armpostgresqlflexibleservers.FirewallRule{
-		"AllowAllAzureServicesAndResources": {
-			Properties: &armpostgresqlflexibleservers.FirewallRuleProperties{
-				StartIPAddress: Ptr("0.0.0.0"),
-				EndIPAddress:   Ptr("0.0.0.0"),
-			},
-		},
-	}
-
-	for _, rule := range databaseConfig.FirewallRules {
-		desiredFirewallRules[rule.Name] = armpostgresqlflexibleservers.FirewallRule{
-			Properties: &armpostgresqlflexibleservers.FirewallRuleProperties{
-				StartIPAddress: Ptr(rule.StartIpAddress),
-				EndIPAddress:   Ptr(rule.EndIpAddress),
+	if inst.Config.Cloud.PrivateNetworking {
+		if err := inst.createPrivateEndpointsForPostgresFlexibleServer(ctx, existingServer); err != nil {
+			return nil, fmt.Errorf("failed to create private endpoints for PostgreSQL server '%s': %w", serverName, err)
+		}
+	} else {
+		desiredFirewallRules := map[string]armpostgresqlflexibleservers.FirewallRule{
+			"AllowAllAzureServicesAndResources": {
+				Properties: &armpostgresqlflexibleservers.FirewallRuleProperties{
+					StartIPAddress: Ptr("0.0.0.0"),
+					EndIPAddress:   Ptr("0.0.0.0"),
+				},
 			},
 		}
-	}
 
-	firewallClient, err := armpostgresqlflexibleservers.NewFirewallRulesClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create PostgreSQL server firewall client: %w", err)
-	}
-
-	existingFirewallRules := make(map[string]armpostgresqlflexibleservers.FirewallRule)
-
-	pager := firewallClient.NewListByServerPager(inst.Config.Cloud.ResourceGroup, serverName, nil)
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list PostgreSQL server firewall rules: %w", err)
-		}
-		for _, fr := range page.Value {
-			existingFirewallRules[*fr.Name] = *fr
-		}
-	}
-
-	if err := createDatabaseServerAdmin(ctx, inst.Config, serverName, inst.Credential); err != nil {
-		return nil, fmt.Errorf("failed to create PostgreSQL server admin: %w", err)
-	}
-
-	promiseGroup := &install.PromiseGroup{}
-
-	for name := range desiredFirewallRules {
-		nameSnapshot := name
-		desiredRule := desiredFirewallRules[nameSnapshot]
-		if existingRule, ok := existingFirewallRules[nameSnapshot]; ok &&
-			*existingRule.Properties.StartIPAddress == *desiredRule.Properties.StartIPAddress &&
-			*existingRule.Properties.EndIPAddress == *desiredRule.Properties.EndIPAddress {
-			continue
-		}
-
-		install.NewPromise(ctx, promiseGroup, func(ctx context.Context) (any, error) {
-			log.Ctx(ctx).Info().Msgf("Creating or updating PostgreSQL server firewall rule '%s'", nameSnapshot)
-			_, err = retryableAsyncOperation(ctx, func(ctx context.Context) (*runtime.Poller[armpostgresqlflexibleservers.FirewallRulesClientCreateOrUpdateResponse], error) {
-				return firewallClient.BeginCreateOrUpdate(ctx, inst.Config.Cloud.ResourceGroup, serverName, nameSnapshot, desiredRule, nil)
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to create PostgreSQL server firewall rule: %w", err)
+		for _, rule := range databaseConfig.FirewallRules {
+			desiredFirewallRules[rule.Name] = armpostgresqlflexibleservers.FirewallRule{
+				Properties: &armpostgresqlflexibleservers.FirewallRuleProperties{
+					StartIPAddress: Ptr(rule.StartIpAddress),
+					EndIPAddress:   Ptr(rule.EndIpAddress),
+				},
 			}
-			return nil, nil
-		})
-	}
+		}
 
-	for name := range existingFirewallRules {
-		nameSnapshot := name
-		if _, ok := desiredFirewallRules[nameSnapshot]; !ok {
+		firewallClient, err := armpostgresqlflexibleservers.NewFirewallRulesClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create PostgreSQL server firewall client: %w", err)
+		}
+
+		existingFirewallRules := make(map[string]armpostgresqlflexibleservers.FirewallRule)
+
+		pager := firewallClient.NewListByServerPager(inst.Config.Cloud.ResourceGroup, serverName, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list PostgreSQL server firewall rules: %w", err)
+			}
+			for _, fr := range page.Value {
+				existingFirewallRules[*fr.Name] = *fr
+			}
+		}
+
+		if err := createDatabaseServerAdmin(ctx, inst.Config, serverName, inst.Credential); err != nil {
+			return nil, fmt.Errorf("failed to create PostgreSQL server admin: %w", err)
+		}
+
+		promiseGroup := &install.PromiseGroup{}
+
+		for name := range desiredFirewallRules {
+			nameSnapshot := name
+			desiredRule := desiredFirewallRules[nameSnapshot]
+			if existingRule, ok := existingFirewallRules[nameSnapshot]; ok &&
+				*existingRule.Properties.StartIPAddress == *desiredRule.Properties.StartIPAddress &&
+				*existingRule.Properties.EndIPAddress == *desiredRule.Properties.EndIPAddress {
+				continue
+			}
+
 			install.NewPromise(ctx, promiseGroup, func(ctx context.Context) (any, error) {
-				log.Ctx(ctx).Info().Msgf("Deleting PostgreSQL server firewall rule '%s'", nameSnapshot)
-				_, err = retryableAsyncOperation(ctx, func(ctx context.Context) (*runtime.Poller[armpostgresqlflexibleservers.FirewallRulesClientDeleteResponse], error) {
-					return firewallClient.BeginDelete(ctx, inst.Config.Cloud.ResourceGroup, serverName, nameSnapshot, nil)
+				log.Ctx(ctx).Info().Msgf("Creating or updating PostgreSQL server firewall rule '%s'", nameSnapshot)
+				_, err = retryableAsyncOperation(ctx, func(ctx context.Context) (*runtime.Poller[armpostgresqlflexibleservers.FirewallRulesClientCreateOrUpdateResponse], error) {
+					return firewallClient.BeginCreateOrUpdate(ctx, inst.Config.Cloud.ResourceGroup, serverName, nameSnapshot, desiredRule, nil)
 				})
 				if err != nil {
-					return nil, fmt.Errorf("failed to delete PostgreSQL server firewall rule: %w", err)
+					return nil, fmt.Errorf("failed to create PostgreSQL server firewall rule: %w", err)
 				}
 				return nil, nil
 			})
 		}
-	}
 
-	// wait for the tasks to complete
-	for _, p := range *promiseGroup {
-		if err := p.AwaitErr(); err != nil && err != install.ErrDependencyFailed {
-			return nil, err
+		for name := range existingFirewallRules {
+			nameSnapshot := name
+			if _, ok := desiredFirewallRules[nameSnapshot]; !ok {
+				install.NewPromise(ctx, promiseGroup, func(ctx context.Context) (any, error) {
+					log.Ctx(ctx).Info().Msgf("Deleting PostgreSQL server firewall rule '%s'", nameSnapshot)
+					_, err = retryableAsyncOperation(ctx, func(ctx context.Context) (*runtime.Poller[armpostgresqlflexibleservers.FirewallRulesClientDeleteResponse], error) {
+						return firewallClient.BeginDelete(ctx, inst.Config.Cloud.ResourceGroup, serverName, nameSnapshot, nil)
+					})
+					if err != nil {
+						return nil, fmt.Errorf("failed to delete PostgreSQL server firewall rule: %w", err)
+					}
+					return nil, nil
+				})
+			}
+		}
+
+		// wait for the tasks to complete
+		for _, p := range *promiseGroup {
+			if err := p.AwaitErr(); err != nil && err != install.ErrDependencyFailed {
+				return nil, err
+			}
 		}
 	}
 
@@ -307,7 +320,7 @@ func (inst *Installer) deleteDatabase(ctx context.Context, org *OrganizationConf
 		return nil, fmt.Errorf("failed to delete PostgreSQL database: %w", err)
 	}
 
-	err = inst.runWithTemporaryFilewallRule(ctx, org, func() error {
+	err = inst.runWithTemporaryFilewallRuleIfNeeded(ctx, org, func() error {
 		currentPrincipalDisplayName, _, _, err := getCurrentPrincipalForDatabase(ctx, inst.Credential)
 		if err != nil {
 			return fmt.Errorf("failed to get current principal information: %w", err)
@@ -383,7 +396,7 @@ func (inst *Installer) createDatabase(ctx context.Context, org *OrganizationConf
 		}
 	}
 
-	err = inst.runWithTemporaryFilewallRule(ctx, org, func() error {
+	err = inst.runWithTemporaryFilewallRuleIfNeeded(ctx, org, func() error {
 		currentPrincipalDisplayName, _, _, err := getCurrentPrincipalForDatabase(ctx, inst.Credential)
 		if err != nil {
 			return fmt.Errorf("failed to get current principal information: %w", err)
@@ -417,7 +430,11 @@ func (inst *Installer) createDatabase(ctx context.Context, org *OrganizationConf
 	return nil, nil
 }
 
-func (inst *Installer) runWithTemporaryFilewallRule(ctx context.Context, org *OrganizationConfig, action func() error) error {
+func (inst *Installer) runWithTemporaryFilewallRuleIfNeeded(ctx context.Context, org *OrganizationConfig, action func() error) error {
+	if !inst.Config.Cloud.PrivateNetworking {
+		return action()
+	}
+
 	temporaryFirewallRuleName := fmt.Sprintf("temp_allow_installer_%s", org.Name)
 	var temporaryFirewallRule *armpostgresqlflexibleservers.FirewallRule
 	// Get the current IP address. Create a new "clean" HTTP client that does not use any proxy, as database connections will not use one.

--- a/cli/internal/install/cloudinstall/dns.go
+++ b/cli/internal/install/cloudinstall/dns.go
@@ -5,16 +5,24 @@ package cloudinstall
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
 	"k8s.io/utils/ptr"
 )
 
 func (inst *Installer) assignDnsRecord(ctx context.Context, org *OrganizationConfig) (any, error) {
 	if inst.Config.Cloud.DnsZone == nil {
 		return nil, nil
+	}
+
+	if inst.Config.Cloud.PrivateNetworking {
+		return nil, inst.assignPrivateDnsRecord(ctx, org)
 	}
 
 	recordSetsClient, err := armdns.NewRecordSetsClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
@@ -58,4 +66,36 @@ func (inst *Installer) deleteDnsRecord(ctx context.Context, org *OrganizationCon
 	}
 
 	return nil, nil
+}
+
+func (inst *Installer) assignPrivateDnsRecord(ctx context.Context, org *OrganizationConfig) error {
+	vnetClient, err := armnetwork.NewVirtualNetworksClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create virtual networks client: %w", err)
+	}
+
+	visitedVnets := make(map[string]any)
+	for _, clusterConfig := range inst.Config.Cloud.Compute.Clusters {
+		vnetResult, err := vnetClient.Get(ctx, clusterConfig.ExistingSubnet.ResourceGroup, clusterConfig.ExistingSubnet.VNetName, nil)
+		if err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+				return fmt.Errorf("VNet '%s' not found in resource group '%s'", clusterConfig.ExistingSubnet.VNetName, clusterConfig.ExistingSubnet.ResourceGroup)
+			}
+
+			return fmt.Errorf("failed to get VNet: %w", err)
+		}
+
+		if _, ok := visitedVnets[*vnetResult.ID]; ok {
+			continue
+		}
+
+		visitedVnets[*vnetResult.ID] = nil
+
+		if err := inst.createPrivateDnsZone(ctx, "traefik-pe-nic", org.Api.DomainName, clusterConfig.ExistingSubnet); err != nil {
+			return fmt.Errorf("failed to create private DNS zone: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/cli/internal/install/cloudinstall/network.go
+++ b/cli/internal/install/cloudinstall/network.go
@@ -1,0 +1,219 @@
+package cloudinstall
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"slices"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v4"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/rs/zerolog/log"
+)
+
+func (inst *Installer) createPrivateEndpointsForStorageAccount(ctx context.Context, targetResource *armstorage.Account) error {
+	return inst.createPrivateEndpoints(ctx, fmt.Sprintf("storage-%s-pe", *targetResource.Name), *targetResource.ID, []*string{Ptr("blob")}, fmt.Sprintf("%s.privatelink.blob.core.windows.net", *targetResource.Name))
+}
+
+func (inst *Installer) createPrivateEndpointsForPostgresFlexibleServer(ctx context.Context, targetResource *armpostgresqlflexibleservers.Server) error {
+	return inst.createPrivateEndpoints(ctx, fmt.Sprintf("postgres-%s-pe", *targetResource.Name), *targetResource.ID, []*string{Ptr("postgresqlServer")}, fmt.Sprintf("%s.privatelink.postgres.database.azure.com", *targetResource.Name))
+}
+
+func (inst *Installer) createPrivateEndpointsForTraefik(ctx context.Context, cluster *armcontainerservice.ManagedCluster) error {
+
+	plServicesClient, err := armnetwork.NewPrivateLinkServicesClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create private link services client: %w", err)
+	}
+
+	plService, err := plServicesClient.Get(ctx, *cluster.Properties.NodeResourceGroup, TraefikPrivateLinkServiceName, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get private link service for Traefik: %w", err)
+	}
+
+	return inst.createPrivateEndpoints(ctx, "traefik-pe", *plService.ID, []*string{}, "")
+}
+
+func (inst *Installer) createPrivateEndpoints(ctx context.Context, privateEndpointName string, targetResourceId string, groupIds []*string, privateDnsZoneName string) error {
+	vnetClient, err := armnetwork.NewVirtualNetworksClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create virtual networks client: %w", err)
+	}
+
+	visitedVnets := make(map[string]any)
+	for _, clusterConfig := range inst.Config.Cloud.Compute.Clusters {
+		vnetResult, err := vnetClient.Get(ctx, clusterConfig.ExistingSubnet.ResourceGroup, clusterConfig.ExistingSubnet.VNetName, nil)
+		if err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+				return fmt.Errorf("VNet '%s' not found in resource group '%s'", clusterConfig.ExistingSubnet.VNetName, clusterConfig.ExistingSubnet.ResourceGroup)
+			}
+
+			return fmt.Errorf("failed to get VNet: %w", err)
+		}
+
+		if _, ok := visitedVnets[*vnetResult.ID]; ok {
+			continue
+		}
+
+		visitedVnets[*vnetResult.ID] = nil
+
+		var subnetId string
+		if subnetIndex := slices.IndexFunc(vnetResult.Properties.Subnets, func(subnet *armnetwork.Subnet) bool {
+			return subnet.Name != nil && *subnet.Name == clusterConfig.ExistingSubnet.SubnetName
+		}); subnetIndex < 0 {
+			return fmt.Errorf("subnet '%s' not found in VNet '%s'", clusterConfig.ExistingSubnet.SubnetName, clusterConfig.ExistingSubnet.VNetName)
+		} else {
+			subnetId = *vnetResult.Properties.Subnets[subnetIndex].ID
+		}
+
+		nicName := fmt.Sprintf("%s-nic", privateEndpointName)
+
+		privateEndpoint := armnetwork.PrivateEndpoint{
+			Location: vnetResult.Location,
+			Properties: &armnetwork.PrivateEndpointProperties{
+				Subnet: &armnetwork.Subnet{
+					ID: &subnetId,
+				},
+				CustomNetworkInterfaceName: &nicName,
+				PrivateLinkServiceConnections: []*armnetwork.PrivateLinkServiceConnection{
+					{
+						Name: &privateEndpointName,
+						Properties: &armnetwork.PrivateLinkServiceConnectionProperties{
+							PrivateLinkServiceID: &targetResourceId,
+							GroupIDs:             groupIds,
+						},
+					},
+				},
+			},
+			Tags: map[string]*string{
+				TagKey: &inst.Config.EnvironmentName,
+			},
+		}
+
+		log.Ctx(ctx).Info().Msgf("Creating or updating private endpoint '%s' for storage account '%s' for subnet '%s' in vnet '%s'", privateEndpointName, path.Base(targetResourceId), clusterConfig.ExistingSubnet.SubnetName, clusterConfig.ExistingSubnet.VNetName)
+
+		privateEndpointClient, err := armnetwork.NewPrivateEndpointsClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create private endpoint client: %w", err)
+		}
+
+		poller, err := privateEndpointClient.BeginCreateOrUpdate(ctx, clusterConfig.ExistingSubnet.PrivateLinkResourceGroup, privateEndpointName, privateEndpoint, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create private endpoint: %w", err)
+		}
+
+		_, err = poller.PollUntilDone(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create private endpoint: %w", err)
+		}
+
+		if privateDnsZoneName != "" {
+			if err := inst.createPrivateDnsZone(ctx, nicName, privateDnsZoneName, clusterConfig.ExistingSubnet); err != nil {
+				return fmt.Errorf("failed to create private DNS zone: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (inst *Installer) createPrivateDnsZone(ctx context.Context, nicName string, domainName string, subnet *SubnetReference) error {
+	privateDNSZoneClient, err := armprivatedns.NewPrivateZonesClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create private DNS zone client: %w", err)
+	}
+
+	log.Ctx(ctx).Info().Msgf("Creating or updating private DNS zone '%s'", domainName)
+
+	dnsZonePoller, err := privateDNSZoneClient.BeginCreateOrUpdate(ctx, subnet.PrivateLinkResourceGroup, domainName, armprivatedns.PrivateZone{
+		Location: Ptr("global"),
+		Tags: map[string]*string{
+			TagKey: &inst.Config.EnvironmentName,
+		},
+	}, nil)
+
+	if err != nil {
+		return fmt.Errorf("failed to create private DNS zone: %w", err)
+	}
+
+	_, err = dnsZonePoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create private DNS zone: %w", err)
+	}
+
+	vnetClient, err := armnetwork.NewVirtualNetworksClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create virtual networks client: %w", err)
+	}
+
+	vnetResult, err := vnetClient.Get(ctx, subnet.ResourceGroup, subnet.VNetName, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get VNet: %w", err)
+	}
+
+	virtualNetworkLinksClient, err := armprivatedns.NewVirtualNetworkLinksClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create virtual network links client: %w", err)
+	}
+
+	linkPoller, err := virtualNetworkLinksClient.BeginCreateOrUpdate(ctx, subnet.PrivateLinkResourceGroup, domainName, fmt.Sprintf("%s-%s", subnet.ResourceGroup, subnet.VNetName),
+		armprivatedns.VirtualNetworkLink{
+			Location: Ptr("global"),
+			Properties: &armprivatedns.VirtualNetworkLinkProperties{
+				RegistrationEnabled: Ptr(false),
+				VirtualNetwork: &armprivatedns.SubResource{
+					ID: vnetResult.ID,
+				},
+			},
+			Tags: map[string]*string{
+				TagKey: &inst.Config.EnvironmentName,
+			},
+		}, nil)
+
+	if err != nil {
+		return fmt.Errorf("failed to create virtual network link: %w", err)
+	}
+
+	_, err = linkPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create virtual network link: %w", err)
+	}
+
+	recordSetsClient, err := armprivatedns.NewRecordSetsClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create record sets client: %w", err)
+	}
+
+	interfacesClient, err := armnetwork.NewInterfacesClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create network interfaces client: %w", err)
+	}
+
+	nic, err := interfacesClient.Get(ctx, subnet.PrivateLinkResourceGroup, nicName, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get network interface '%s': %w", nicName)
+	}
+
+	_, err = recordSetsClient.CreateOrUpdate(ctx, subnet.PrivateLinkResourceGroup, domainName, armprivatedns.RecordTypeA, "@",
+		armprivatedns.RecordSet{Properties: &armprivatedns.RecordSetProperties{
+			ARecords: []*armprivatedns.ARecord{
+				{
+					IPv4Address: nic.Properties.IPConfigurations[0].Properties.PrivateIPAddress,
+				},
+			},
+			TTL: Ptr[int64](3600),
+		}}, nil)
+
+	if err != nil {
+		return fmt.Errorf("failed to create A record in private DNS zone: %w", err)
+	}
+
+	return nil
+}

--- a/cli/internal/install/cloudinstall/network.go
+++ b/cli/internal/install/cloudinstall/network.go
@@ -18,113 +18,100 @@ import (
 )
 
 func (inst *Installer) createPrivateEndpointsForStorageAccount(ctx context.Context, targetResource *armstorage.Account) error {
-	return inst.createPrivateEndpoints(ctx, fmt.Sprintf("storage-%s-pe", *targetResource.Name), *targetResource.ID, []*string{Ptr("blob")}, fmt.Sprintf("%s.privatelink.blob.core.windows.net", *targetResource.Name))
+	return inst.forEachVnet(ctx, func(ctx context.Context, vnet *armnetwork.VirtualNetwork, subnet *armnetwork.Subnet, configSubnet *SubnetReference) error {
+		return inst.createPrivateEndpoints(ctx, fmt.Sprintf("storage-%s-pe", *targetResource.Name), *targetResource.ID, []*string{Ptr("blob")}, fmt.Sprintf("%s.privatelink.blob.core.windows.net", *targetResource.Name), vnet, subnet, configSubnet)
+	})
 }
 
 func (inst *Installer) createPrivateEndpointsForPostgresFlexibleServer(ctx context.Context, targetResource *armpostgresqlflexibleservers.Server) error {
-	return inst.createPrivateEndpoints(ctx, fmt.Sprintf("postgres-%s-pe", *targetResource.Name), *targetResource.ID, []*string{Ptr("postgresqlServer")}, fmt.Sprintf("%s.privatelink.postgres.database.azure.com", *targetResource.Name))
+	return inst.forEachVnet(ctx, func(ctx context.Context, vnet *armnetwork.VirtualNetwork, subnet *armnetwork.Subnet, configSubnet *SubnetReference) error {
+		return inst.createPrivateEndpoints(ctx, fmt.Sprintf("postgres-%s-pe", *targetResource.Name), *targetResource.ID, []*string{Ptr("postgresqlServer")}, fmt.Sprintf("%s.privatelink.postgres.database.azure.com", *targetResource.Name), vnet, subnet, configSubnet)
+	})
 }
 
 func (inst *Installer) createPrivateEndpointsForTraefik(ctx context.Context, cluster *armcontainerservice.ManagedCluster) error {
-
 	plServicesClient, err := armnetwork.NewPrivateLinkServicesClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create private link services client: %w", err)
 	}
 
-	plService, err := plServicesClient.Get(ctx, *cluster.Properties.NodeResourceGroup, TraefikPrivateLinkServiceName, nil)
-	if err != nil {
-		return fmt.Errorf("failed to get private link service for Traefik: %w", err)
-	}
+	return inst.forEachVnet(ctx, func(ctx context.Context, vnet *armnetwork.VirtualNetwork, subnet *armnetwork.Subnet, configSubnet *SubnetReference) error {
+		if configSubnet.VNetResourceId == *vnet.ID {
+			// no need to create private endpoint for Traefik if the VNet is the same as the one used for the cluster
+			return nil
+		}
 
-	return inst.createPrivateEndpoints(ctx, "traefik-pe", *plService.ID, []*string{}, "")
+		plService, err := plServicesClient.Get(ctx, *cluster.Properties.NodeResourceGroup, TraefikPrivateLinkServiceName, nil)
+		if err != nil {
+			return fmt.Errorf("failed to get private link service for Traefik: %w", err)
+		}
+
+		return inst.createPrivateEndpoints(ctx, "traefik-pe", *plService.ID, []*string{}, "", vnet, subnet, configSubnet)
+	})
 }
 
-func (inst *Installer) createPrivateEndpoints(ctx context.Context, privateEndpointName string, targetResourceId string, groupIds []*string, privateDnsZoneName string) error {
-	vnetClient, err := armnetwork.NewVirtualNetworksClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create virtual networks client: %w", err)
-	}
+func (inst *Installer) createPrivateEndpoints(ctx context.Context, privateEndpointName string, targetResourceId string, groupIds []*string, privateDnsZoneName string, vnet *armnetwork.VirtualNetwork, subnet *armnetwork.Subnet, configSubnet *SubnetReference) error {
+	nicName := fmt.Sprintf("%s-nic", privateEndpointName)
 
-	visitedVnets := make(map[string]any)
-	for _, clusterConfig := range inst.Config.Cloud.Compute.Clusters {
-		vnetResult, err := vnetClient.Get(ctx, clusterConfig.ExistingSubnet.ResourceGroup, clusterConfig.ExistingSubnet.VNetName, nil)
-		if err != nil {
-			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("VNet '%s' not found in resource group '%s'", clusterConfig.ExistingSubnet.VNetName, clusterConfig.ExistingSubnet.ResourceGroup)
-			}
-
-			return fmt.Errorf("failed to get VNet: %w", err)
-		}
-
-		if _, ok := visitedVnets[*vnetResult.ID]; ok {
-			continue
-		}
-
-		visitedVnets[*vnetResult.ID] = nil
-
-		var subnetId string
-		if subnetIndex := slices.IndexFunc(vnetResult.Properties.Subnets, func(subnet *armnetwork.Subnet) bool {
-			return subnet.Name != nil && *subnet.Name == clusterConfig.ExistingSubnet.SubnetName
-		}); subnetIndex < 0 {
-			return fmt.Errorf("subnet '%s' not found in VNet '%s'", clusterConfig.ExistingSubnet.SubnetName, clusterConfig.ExistingSubnet.VNetName)
-		} else {
-			subnetId = *vnetResult.Properties.Subnets[subnetIndex].ID
-		}
-
-		nicName := fmt.Sprintf("%s-nic", privateEndpointName)
-
-		privateEndpoint := armnetwork.PrivateEndpoint{
-			Location: vnetResult.Location,
-			Properties: &armnetwork.PrivateEndpointProperties{
-				Subnet: &armnetwork.Subnet{
-					ID: &subnetId,
-				},
-				CustomNetworkInterfaceName: &nicName,
-				PrivateLinkServiceConnections: []*armnetwork.PrivateLinkServiceConnection{
-					{
-						Name: &privateEndpointName,
-						Properties: &armnetwork.PrivateLinkServiceConnectionProperties{
-							PrivateLinkServiceID: &targetResourceId,
-							GroupIDs:             groupIds,
-						},
+	privateEndpoint := armnetwork.PrivateEndpoint{
+		Location: vnet.Location,
+		Properties: &armnetwork.PrivateEndpointProperties{
+			Subnet: &armnetwork.Subnet{
+				ID: subnet.ID,
+			},
+			CustomNetworkInterfaceName: &nicName,
+			PrivateLinkServiceConnections: []*armnetwork.PrivateLinkServiceConnection{
+				{
+					Name: &privateEndpointName,
+					Properties: &armnetwork.PrivateLinkServiceConnectionProperties{
+						PrivateLinkServiceID: &targetResourceId,
+						GroupIDs:             groupIds,
 					},
 				},
 			},
-			Tags: map[string]*string{
-				TagKey: &inst.Config.EnvironmentName,
-			},
-		}
+		},
+		Tags: map[string]*string{
+			TagKey: &inst.Config.EnvironmentName,
+		},
+	}
 
-		log.Ctx(ctx).Info().Msgf("Creating or updating private endpoint '%s' for storage account '%s' for subnet '%s' in vnet '%s'", privateEndpointName, path.Base(targetResourceId), clusterConfig.ExistingSubnet.SubnetName, clusterConfig.ExistingSubnet.VNetName)
+	log.Ctx(ctx).Info().Msgf("Creating or updating private endpoint '%s' for storage account '%s' for subnet '%s' in vnet '%s'", privateEndpointName, path.Base(targetResourceId), configSubnet.SubnetName, configSubnet.VNetName)
 
-		privateEndpointClient, err := armnetwork.NewPrivateEndpointsClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	privateEndpointClient, err := armnetwork.NewPrivateEndpointsClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create private endpoint client: %w", err)
+	}
+
+	poller, err := privateEndpointClient.BeginCreateOrUpdate(ctx, configSubnet.PrivateLinkResourceGroup, privateEndpointName, privateEndpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create private endpoint: %w", err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create private endpoint: %w", err)
+	}
+
+	if privateDnsZoneName != "" {
+		interfacesClient, err := armnetwork.NewInterfacesClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
 		if err != nil {
-			return fmt.Errorf("failed to create private endpoint client: %w", err)
+			return fmt.Errorf("failed to create network interfaces client: %w", err)
 		}
 
-		poller, err := privateEndpointClient.BeginCreateOrUpdate(ctx, clusterConfig.ExistingSubnet.PrivateLinkResourceGroup, privateEndpointName, privateEndpoint, nil)
+		nic, err := interfacesClient.Get(ctx, configSubnet.PrivateLinkResourceGroup, nicName, nil)
 		if err != nil {
-			return fmt.Errorf("failed to create private endpoint: %w", err)
+			return fmt.Errorf("failed to get network interface '%s': %w", nicName, err)
 		}
 
-		_, err = poller.PollUntilDone(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create private endpoint: %w", err)
-		}
-
-		if privateDnsZoneName != "" {
-			if err := inst.createPrivateDnsZone(ctx, nicName, privateDnsZoneName, clusterConfig.ExistingSubnet); err != nil {
-				return fmt.Errorf("failed to create private DNS zone: %w", err)
-			}
+		if err := inst.createPrivateDnsZone(ctx, privateDnsZoneName, *nic.Properties.IPConfigurations[0].Properties.PrivateIPAddress, configSubnet); err != nil {
+			return fmt.Errorf("failed to create private DNS zone: %w", err)
 		}
 	}
 
 	return nil
 }
 
-func (inst *Installer) createPrivateDnsZone(ctx context.Context, nicName string, domainName string, subnet *SubnetReference) error {
+func (inst *Installer) createPrivateDnsZone(ctx context.Context, domainName string, ipAddress string, subnet *SubnetReference) error {
 	privateDNSZoneClient, err := armprivatedns.NewPrivateZonesClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create private DNS zone client: %w", err)
@@ -191,21 +178,11 @@ func (inst *Installer) createPrivateDnsZone(ctx context.Context, nicName string,
 		return fmt.Errorf("failed to create record sets client: %w", err)
 	}
 
-	interfacesClient, err := armnetwork.NewInterfacesClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create network interfaces client: %w", err)
-	}
-
-	nic, err := interfacesClient.Get(ctx, subnet.PrivateLinkResourceGroup, nicName, nil)
-	if err != nil {
-		return fmt.Errorf("failed to get network interface '%s': %w", nicName)
-	}
-
 	_, err = recordSetsClient.CreateOrUpdate(ctx, subnet.PrivateLinkResourceGroup, domainName, armprivatedns.RecordTypeA, "@",
 		armprivatedns.RecordSet{Properties: &armprivatedns.RecordSetProperties{
 			ARecords: []*armprivatedns.ARecord{
 				{
-					IPv4Address: nic.Properties.IPConfigurations[0].Properties.PrivateIPAddress,
+					IPv4Address: &ipAddress,
 				},
 			},
 			TTL: Ptr[int64](3600),
@@ -213,6 +190,47 @@ func (inst *Installer) createPrivateDnsZone(ctx context.Context, nicName string,
 
 	if err != nil {
 		return fmt.Errorf("failed to create A record in private DNS zone: %w", err)
+	}
+
+	return nil
+}
+
+func (inst *Installer) forEachVnet(ctx context.Context, action func(ctx context.Context, vnet *armnetwork.VirtualNetwork, subnet *armnetwork.Subnet, configSubnet *SubnetReference) error) error {
+	vnetClient, err := armnetwork.NewVirtualNetworksClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create virtual networks client: %w", err)
+	}
+
+	visitedVnets := make(map[string]any)
+	for _, clusterConfig := range inst.Config.Cloud.Compute.Clusters {
+		vnetResult, err := vnetClient.Get(ctx, clusterConfig.ExistingSubnet.ResourceGroup, clusterConfig.ExistingSubnet.VNetName, nil)
+		if err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+				return fmt.Errorf("VNet '%s' not found in resource group '%s'", clusterConfig.ExistingSubnet.VNetName, clusterConfig.ExistingSubnet.ResourceGroup)
+			}
+
+			return fmt.Errorf("failed to get VNet: %w", err)
+		}
+
+		if _, ok := visitedVnets[*vnetResult.ID]; ok {
+			continue
+		}
+
+		visitedVnets[*vnetResult.ID] = nil
+
+		var subnet *armnetwork.Subnet
+		if subnetIndex := slices.IndexFunc(vnetResult.Properties.Subnets, func(subnet *armnetwork.Subnet) bool {
+			return subnet.Name != nil && *subnet.Name == clusterConfig.ExistingSubnet.SubnetName
+		}); subnetIndex < 0 {
+			return fmt.Errorf("subnet '%s' not found in VNet '%s'", clusterConfig.ExistingSubnet.SubnetName, clusterConfig.ExistingSubnet.VNetName)
+		} else {
+			subnet = vnetResult.Properties.Subnets[subnetIndex]
+		}
+
+		if err := action(ctx, &vnetResult.VirtualNetwork, subnet, clusterConfig.ExistingSubnet); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cli/internal/install/cloudinstall/validation.go
+++ b/cli/internal/install/cloudinstall/validation.go
@@ -168,6 +168,10 @@ func quickValidateComputeConfig(ctx context.Context, success *bool, cloudConfig 
 			armcontainerservice.PossibleManagedClusterSKUTierValues(),
 			fmt.Sprintf("The `sku` field must be one of %%v for cluster '%s'", cluster.Name))
 
+		if cloudConfig.PrivateNetworking && cluster.ExistingSubnet == nil {
+			validationError(ctx, success, "Since `cloud.privateNetworking` is enabled, `existingSubnet` must be specified on cluster '%s'", cluster.Name)
+		}
+
 		if cluster.ExistingSubnet != nil {
 			if cluster.ExistingSubnet.ResourceGroup == "" {
 				validationError(ctx, success, "Since `existingSubnet` is specified, `existingSubnet.resourceGroup` is required on cluster `%s`", cluster.Name)
@@ -184,6 +188,9 @@ func quickValidateComputeConfig(ctx context.Context, success *bool, cloudConfig 
 			if cloudConfig.PrivateNetworking {
 				cluster.ExistingSubnet.PrivateLinkResourceGroup = fmt.Sprintf("%s-privatelink-%s-%s", cloudConfig.ResourceGroup, cluster.ExistingSubnet.ResourceGroup, cluster.ExistingSubnet.VNetName)
 			}
+
+			cluster.ExistingSubnet.VNetResourceId = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s", cloudConfig.SubscriptionID, cluster.ExistingSubnet.ResourceGroup, cluster.ExistingSubnet.VNetName)
+			cluster.ExistingSubnet.SubnetResourceId = fmt.Sprintf("%s/subnets/%s", cluster.ExistingSubnet.VNetResourceId, cluster.ExistingSubnet.SubnetName)
 		}
 
 		if cluster.SystemNodePool == nil {

--- a/deploy/config/microsoft/cloudconfig-private-link.yml
+++ b/deploy/config/microsoft/cloudconfig-private-link.yml
@@ -10,7 +10,7 @@ cloud:
   # Whether to use private networking. The default is false.
   # If true, Tyger service, storage storage accounts, and all other created resources
   # will not be accessible from the public internet.
-  privateNetworking: false
+  privateNetworking: true
 
   # Optionally point an existing Log Analytics workspace to send logs to.
   logAnalyticsWorkspace:
@@ -38,10 +38,10 @@ cloud:
         # location: defaults to Standard
 
         # An existing virtual network subnet to deploy the cluster into.
-        # existingSubnet:
-        #   resourceGroup:
-        #   vnetName:
-        #   subnetName:
+        existingSubnet:
+          resourceGroup: eminence
+          vnetName: eminence-pl-${TYGER_LOCATION}-vnet
+          subnetName: default
 
         systemNodePool:
           name: system
@@ -117,13 +117,6 @@ cloud:
     # Firewall rules to control where the database can be accessed from,
     # in addition to the control-plane cluster.
     firewallRules: ${TYGER_ENVIRONMENT_FIREWALL_RULES}
-
-  networkSecurityPerimeter:
-    nspResourceGroup: NSP-ALL
-    nspName: defaultNSP
-    storageProfile:
-      name: storageaccounts
-      mode: Learning
 
 organizations:
   - name: lamna
@@ -211,106 +204,6 @@ organizations:
             - kind: ServicePrincipal
               objectId: 15bf92f7-9210-480f-a6ad-8d576d0baac7
               displayName: tyger-client-contributor
-
-      buffers:
-        # TTL for active buffers before they are automatically soft-deleted (D.HH:MM:SS) (0 = never expire)
-        activeLifetime: 0.00:00
-        # TTL for soft-deleted buffers before they are automatically purged forever (D.HH:MM:SS) (0 = purge immediately)
-        softDeletedLifetime: 1.00:00
-
-      # Optional Helm chart overrides
-      helm:
-        tyger:
-          # repoName:
-          # repoUrl: not set if using `chartRef`
-          chartRef: ${TYGER_HELM_CHART_DIR}
-          # version:
-          values:
-            bufferCopierImage: ${BUFFER_COPIER_IMAGE}
-            bufferSidecarImage: ${BUFFER_SIDECAR_IMAGE}
-            image: ${TYGER_SERVER_IMAGE}
-            workerWaiterImage: ${WORKER_WAITER_IMAGE}
-
-  - name: legacy
-    singleOrganizationCompatibilityMode: true
-    cloud:
-      storage:
-        # Storage accounts for buffers.
-        buffers:
-          - name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}legacybuf
-            # location: defaults to defaultLocation
-            # sku: defaults to Standard_LRS
-            # dnsEndpointType can be set to `AzureDNSZone` when creating large number of accounts in a single subscription.
-            # dnsEndpointType: defaults to Standard.
-
-        # defaultBufferLocation: Can be set if there are buffer storage accounts in multiple locations
-
-        # The storage account where run logs will be stored.
-        logs:
-          name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}legacylog
-          # location: defaults to defaultLocation
-          # sku: defaults to Standard_LRS
-          # dnsEndpointType can be set to `AzureDNSZone` when creating large number of accounts in a single subscription.
-          # dnsEndpointType: defaults to Standard.
-
-      # An optional array of managed identities that will be created in the resource group.
-      # These identities are available to runs as workload identities. When updating this list
-      # both `tyger cloud install` and `tyger api installed` must be run.
-      identities:
-        - test-identity
-
-    api:
-      # The fully qualified domain name for the Tyger API.
-      domainName: ${TYGER_ENVIRONMENT_NAME}-tyger.${TYGER_LOCATION}.cloudapp.azure.com
-
-      # Set to KeyVault if using a custom TLS certificate, otherwise set to LetsEncrypt
-      tlsCertificateProvider: LetsEncrypt
-
-      accessControl:
-        tenantId: 76d3279b-830e-4bea-baf8-12863cdeba4c
-        apiAppUri: api://tyger-server
-        cliAppUri: api://tyger-cli
-
-        apiAppId: e8229c82-a93e-4a2a-a983-d3ed35f2f62c
-        cliAppId: f13d0630-3b5f-4a9f-aafa-34bd3bb6062b
-
-        # Principals in role assignments are specified in the following ways:
-        #
-        # For users, specify the object ID and/or the user principal name.
-        #   - kind: User
-        #     objectId: <objectId>
-        #     userPrincipalName: <userPrincipalName>
-        #
-        # For groups, specify the object ID and/or the group display name.
-        #   - kind: Group
-        #     objectId: <objectId>
-        #     displayName: <displayName>
-        #
-        # For service principals, specify the object ID and/or the service principal display name.
-        #   - kind: ServicePrincipal
-        #     objectId: <objectId>
-        #     displayName: <displayName>
-
-        # Example:
-        #
-        # roleAssignments:
-        #   owner:
-        #     - kind: User
-        #       objectId: c5e5d858-b954-4bef-b704-71b63e761f69
-        #       userPrincipalName: me@example.com
-        #
-        #     - kind: ServicePrincipal
-        #       objectId: 32b73951-e5eb-4a75-8479-23374021f46a
-        #       displayName: my-service-principal
-        #
-        #   contributor:
-        #     - kind: Group
-        #       objectId: f939c89c-94ed-46b9-8fbd-726cf747f231
-        #       displayName: my-group
-
-        roleAssignments:
-          owner: []
-          contributor: []
 
       buffers:
         # TTL for active buffers before they are automatically soft-deleted (D.HH:MM:SS) (0 = never expire)

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -7,6 +7,11 @@ cloud:
   resourceGroup: ${TYGER_ENVIRONMENT_NAME}
   defaultLocation: ${TYGER_LOCATION}
 
+  # Whether to use private networking. The default is false.
+  # If true, Tyger service, storage storage accounts, and all other created resources
+  # will not be accessible from the public internet.
+  privateNetworking: true
+
   # Optionally point an existing Log Analytics workspace to send logs to.
   logAnalyticsWorkspace:
     resourceGroup: eminence
@@ -24,8 +29,6 @@ cloud:
       name: eminence
     certificateName: eminence-tls-cert
 
-  privateNetworking: true
-
   compute:
     clusters:
       - name: ${TYGER_ENVIRONMENT_NAME}
@@ -34,6 +37,7 @@ cloud:
         sku: Standard
         # location: defaults to Standard
 
+        # An existing virtual network subnet to deploy the cluster into.
         existingSubnet:
           resourceGroup: jostairsdemo
           vnetName: jostairsdemo-vnet

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -24,6 +24,8 @@ cloud:
       name: eminence
     certificateName: eminence-tls-cert
 
+  privateNetworking: true
+
   compute:
     clusters:
       - name: ${TYGER_ENVIRONMENT_NAME}
@@ -31,6 +33,12 @@ cloud:
         kubernetesVersion: "1.32"
         sku: Standard
         # location: defaults to Standard
+
+        existingSubnet:
+          resourceGroup: jostairsdemo
+          vnetName: jostairsdemo-vnet
+          subnetName: tyger
+
         systemNodePool:
           name: system
           vmSize: ${TYGER_SYSTEM_NODE_SKU}
@@ -199,106 +207,6 @@ organizations:
             - kind: ServicePrincipal
               objectId: 15bf92f7-9210-480f-a6ad-8d576d0baac7
               displayName: tyger-client-contributor
-
-      buffers:
-        # TTL for active buffers before they are automatically soft-deleted (D.HH:MM:SS) (0 = never expire)
-        activeLifetime: 0.00:00
-        # TTL for soft-deleted buffers before they are automatically purged forever (D.HH:MM:SS) (0 = purge immediately)
-        softDeletedLifetime: 1.00:00
-
-      # Optional Helm chart overrides
-      helm:
-        tyger:
-          # repoName:
-          # repoUrl: not set if using `chartRef`
-          chartRef: ${TYGER_HELM_CHART_DIR}
-          # version:
-          values:
-            bufferCopierImage: ${BUFFER_COPIER_IMAGE}
-            bufferSidecarImage: ${BUFFER_SIDECAR_IMAGE}
-            image: ${TYGER_SERVER_IMAGE}
-            workerWaiterImage: ${WORKER_WAITER_IMAGE}
-
-  - name: legacy
-    singleOrganizationCompatibilityMode: true
-    cloud:
-      storage:
-        # Storage accounts for buffers.
-        buffers:
-          - name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}legacybuf
-            # location: defaults to defaultLocation
-            # sku: defaults to Standard_LRS
-            # dnsEndpointType can be set to `AzureDNSZone` when creating large number of accounts in a single subscription.
-            # dnsEndpointType: defaults to Standard.
-
-        # defaultBufferLocation: Can be set if there are buffer storage accounts in multiple locations
-
-        # The storage account where run logs will be stored.
-        logs:
-          name: ${TYGER_ENVIRONMENT_NAME_NO_DASHES}legacylog
-          # location: defaults to defaultLocation
-          # sku: defaults to Standard_LRS
-          # dnsEndpointType can be set to `AzureDNSZone` when creating large number of accounts in a single subscription.
-          # dnsEndpointType: defaults to Standard.
-
-      # An optional array of managed identities that will be created in the resource group.
-      # These identities are available to runs as workload identities. When updating this list
-      # both `tyger cloud install` and `tyger api installed` must be run.
-      identities:
-        - test-identity
-
-    api:
-      # The fully qualified domain name for the Tyger API.
-      domainName: ${TYGER_ENVIRONMENT_NAME}-tyger.${TYGER_LOCATION}.cloudapp.azure.com
-
-      # Set to KeyVault if using a custom TLS certificate, otherwise set to LetsEncrypt
-      tlsCertificateProvider: LetsEncrypt
-
-      accessControl:
-        tenantId: 76d3279b-830e-4bea-baf8-12863cdeba4c
-        apiAppUri: api://tyger-server
-        cliAppUri: api://tyger-cli
-
-        apiAppId: e8229c82-a93e-4a2a-a983-d3ed35f2f62c
-        cliAppId: f13d0630-3b5f-4a9f-aafa-34bd3bb6062b
-
-        # Principals in role assignments are specified in the following ways:
-        #
-        # For users, specify the object ID and/or the user principal name.
-        #   - kind: User
-        #     objectId: <objectId>
-        #     userPrincipalName: <userPrincipalName>
-        #
-        # For groups, specify the object ID and/or the group display name.
-        #   - kind: Group
-        #     objectId: <objectId>
-        #     displayName: <displayName>
-        #
-        # For service principals, specify the object ID and/or the service principal display name.
-        #   - kind: ServicePrincipal
-        #     objectId: <objectId>
-        #     displayName: <displayName>
-
-        # Example:
-        #
-        # roleAssignments:
-        #   owner:
-        #     - kind: User
-        #       objectId: c5e5d858-b954-4bef-b704-71b63e761f69
-        #       userPrincipalName: me@example.com
-        #
-        #     - kind: ServicePrincipal
-        #       objectId: 32b73951-e5eb-4a75-8479-23374021f46a
-        #       displayName: my-service-principal
-        #
-        #   contributor:
-        #     - kind: Group
-        #       objectId: f939c89c-94ed-46b9-8fbd-726cf747f231
-        #       displayName: my-group
-
-        roleAssignments:
-          owner: []
-          contributor: []
 
       buffers:
         # TTL for active buffers before they are automatically soft-deleted (D.HH:MM:SS) (0 = never expire)

--- a/docs/introduction/installation/cloud-installation.md
+++ b/docs/introduction/installation/cloud-installation.md
@@ -62,6 +62,11 @@ cloud:
   resourceGroup: demo
   defaultLocation: westus2
 
+  # Whether to use private networking. The default is false.
+  # If true, Tyger service, storage storage accounts, and all other created resources
+  # will not be accessible from the public internet.
+  privateNetworking: false
+
   # Optionally point an existing Log Analytics workspace to send logs to.
   # logAnalyticsWorkspace:
     # resourceGroup:
@@ -86,6 +91,13 @@ cloud:
         kubernetesVersion: "1.32"
         sku:
         # location: defaults to Standard
+
+        # An existing virtual network subnet to deploy the cluster into.
+        # existingSubnet:
+          # resourceGroup:
+          # vnetName:
+          # subnetName:
+
         systemNodePool:
           name: system
           vmSize: Standard_DS2_v2
@@ -173,6 +185,8 @@ organizations:
             # dnsEndpointType can be set to `AzureDNSZone` when creating large number of accounts in a single subscription.
             # dnsEndpointType: defaults to Standard.
 
+        # defaultBufferLocation: Can be set if there are buffer storage accounts in multiple locations
+
         # The storage account where run logs will be stored.
         logs:
           name: demotygerlogs
@@ -218,23 +232,6 @@ organizations:
         #   - kind: ServicePrincipal
         #     objectId: <objectId>
         #     displayName: <displayName>
-
-        # Example:
-        #
-        # roleAssignments:
-        #   owner:
-        #     - kind: User
-        #       objectId: c5e5d858-b954-4bef-b704-71b63e761f69
-        #       userPrincipalName: me@example.com
-        #
-        #     - kind: ServicePrincipal
-        #       objectId: 32b73951-e5eb-4a75-8479-23374021f46a
-        #       displayName: my-service-principal
-        #
-        #   contributor:
-        #     - kind: Group
-        #       objectId: f939c89c-94ed-46b9-8fbd-726cf747f231
-        #       displayName: my-group
 
         roleAssignments:
           owner:
@@ -406,6 +403,25 @@ tyger cloud uninstall -f config.yml --all
 ::: danger Warning
 `tyger cloud uninstall` will permanently delete all database and buffer data.
 :::
+
+## Private netorking
+
+Currently a preview feature, the entire Tyger environment can use private
+networking, meaning that none of the endpoints can be accessed from the public
+internet.
+
+To enable this mode, you will need to create an Azure virtual network (VNet) for
+the Kubernetes cluster to be deployed into. You will reference a subnet in this
+this VNet in the `cloud.compute.clusters.existingSubnet` field. To enable
+private networking, set the `cloud.privateNetworking` field to `true`.
+
+This mode cannot use Let's Encrypt for TLS certificate creation, and you will
+need to provide your own TLS certificate in a referenced Key Vault. If you want
+to use private networking for this Key Vault, you will need to create private
+endpoints for the Key Vault in the subnet before running `tyger cloud install`.
+
+You will need to run tyger commands, including the installation commands from a
+virtual machine in this VNet, or set up peering and DNS forwarning to this VNet.
 
 
 ## Multi-tenancy

--- a/scripts/get-config.sh
+++ b/scripts/get-config.sh
@@ -74,6 +74,8 @@ done
 this_dir=$(dirname "${0}")
 config_dir=$(realpath "${TYGER_ENVIRONMENT_CONFIG_DIR:-${this_dir}/../deploy/config/microsoft}")
 
+use_private_link="${TYGER_USE_PRIVATE_LINK:-false}"
+
 devconfig_path="${config_dir}/devconfig.yml"
 
 if [[ "$dev" == true ]]; then
@@ -85,7 +87,11 @@ else
     TYGER_INSTALLATION_PATH="$(realpath "${this_dir}/../install/local")"
     export TYGER_INSTALLATION_PATH
   else
-    config_path="${config_dir}/cloudconfig.yml"
+    if [[ "$use_private_link" == true ]]; then
+      config_path="${config_dir}/cloudconfig-private-link.yml"
+    else
+      config_path="${config_dir}/cloudconfig.yml"
+    fi
 
     environment_name="${TYGER_ENVIRONMENT_NAME:-}"
     if [[ -z "${environment_name:-}" ]]; then
@@ -94,6 +100,10 @@ else
         exit 1
       fi
       environment_name="${BASH_REMATCH[0]//[.\-_]/}"
+
+      if [[ "$use_private_link" == true ]]; then
+        environment_name="${environment_name}private"
+      fi
     fi
     export TYGER_ENVIRONMENT_NAME="${environment_name}"
     export TYGER_ENVIRONMENT_NAME_NO_DASHES="${environment_name//-/}"
@@ -119,6 +129,8 @@ else
 
       export TYGER_SECONDARY_LOCATION="${TYGER_SECONDARY_LOCATION:-eastus}"
     fi
+
+
 
   fi
 

--- a/scripts/get-config.sh
+++ b/scripts/get-config.sh
@@ -130,8 +130,6 @@ else
       export TYGER_SECONDARY_LOCATION="${TYGER_SECONDARY_LOCATION:-eastus}"
     fi
 
-
-
   fi
 
   repo_fqdn=$(envsubst <"${devconfig_path}" | yq ".wipContainerRegistry.fqdn")


### PR DESCRIPTION
Preview of private networking support.

To create a development Tyger environment, set the environment `TYGER_USE_PRIVATE_LINK` to `true`. You will need to create a VM that is part of the `eminence-pl-westus2-vnet` or `eminence-pl-eastus-vnet` VNet, depending on your configuration, and then run all `tyger` commands from this VM.