### PR TITLE
Add `x5c` header when using a certificate from a Windows cert store 

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -157,7 +157,7 @@ jobs:
     outputs:
       IMAGE_TAG: ${{ steps.set-variables.outputs.IMAGE_TAG }}
       TYGER_ENVIRONMENT_NAME: ${{ steps.set-variables.outputs.TYGER_ENVIRONMENT_NAME }}
-      TYGER_LEGACY_URL: ${{ steps.set-variables.outputs.TYGER_LEGACY_URL }}
+      TYGER_URL: ${{ steps.set-variables.outputs.TYGER_URL }}
       DEVELOPER_CONFIG_BASE64: ${{ steps.set-variables.outputs.DEVELOPER_CONFIG_BASE64 }}
     steps:
       - name: Checkout
@@ -202,8 +202,8 @@ jobs:
 
           export TYGER_ENVIRONMENT_NAME="${environment_name}"
 
-          tyger_legacy_url=$(make -s get-tyger-url TYGER_ORG=legacy)
-          echo "TYGER_LEGACY_URL=$tyger_legacy_url" >> "$GITHUB_OUTPUT"
+          tyger_url=$(make -s get-tyger-url)
+          echo "TYGER_URL=$tyger_url" >> "$GITHUB_OUTPUT"
 
           echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_OUTPUT"
           echo "TYGER_ENVIRONMENT_NAME=$environment_name" >> "$GITHUB_ENV"
@@ -555,7 +555,7 @@ jobs:
       - name: Run smoke tests
         env:
           DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
-          TYGER_LEGACY_URL: ${{ needs.get-config.outputs.TYGER_LEGACY_URL }}
+          TYGER_URL: ${{ needs.get-config.outputs.TYGER_URL }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -571,8 +571,8 @@ jobs:
 
           # Run tests
           .\scripts\Test-CertificateLoginOnWindows.ps1 `
-            -ServerUrl $env:TYGER_LEGACY_URL `
-            -ServicePrincipal "api://tyger-test-client" `
+            -ServerUrl $env:TYGER_URL `
+            -ServicePrincipal "api://tyger-client-owner" `
             -KeyVaultName $keyVaultName `
             -CertificateName $certificateName `
             -CertificateVersion $certificateVersion


### PR DESCRIPTION
Ensuring we add the `x5c` header to token endpoint requests when using certificates from the Windows certificate store. 