### PR TITLE
Use MISE in internal environments

### DIFF
--- a/cli/internal/cmd/install/accesscontrol.go
+++ b/cli/internal/cmd/install/accesscontrol.go
@@ -161,8 +161,10 @@ func newAccessControlApplyCommand() *cobra.Command {
 				if orgConfig.Api == nil {
 					log.Fatal().Msg("The `api` field is required in the organization configuration")
 				}
-				desiredAccessControlConfig = orgConfig.Api.AccessControl
-				if desiredAccessControlConfig == nil {
+
+				if ac := orgConfig.Api.AccessControl; ac != nil {
+					desiredAccessControlConfig = &ac.AccessControlConfig
+				} else {
 					log.Fatal().Msg("The `api.accessControl` field is required in the organization configuration")
 				}
 

--- a/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
+++ b/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
@@ -277,7 +277,11 @@ organizations:
       # Set to KeyVault if using a custom TLS certificate, otherwise set to LetsEncrypt
       tlsCertificateProvider: {{ .TlsCertificateProvider }}
 
-      accessControl: {{- renderAccessControlConfig .AccessControl | trim | nindent 8 }}
+      accessControl: {{- renderAccessControlConfig .AccessControl.AccessControlConfig | trim | nindent 8 }}
+      {{- if .AccessControl.MiseImage }}
+
+        miseImage: {{ .AccessControl.MiseImage }}
+      {{ end -}}
       {{- if (and .Buffers (or .Buffers.ActiveLifetime .Buffers.SoftDeletedLifetime)) }}
 
       buffers:

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -260,16 +260,21 @@ const (
 )
 
 type OrganizationApiConfig struct {
-	DomainName             string                  `yaml:"domainName"`
-	TlsCertificateProvider TlsCertificateProvider  `yaml:"tlsCertificateProvider"`
-	AccessControl          *AccessControlConfig    `yaml:"accessControl"`
-	Buffers                *BuffersConfig          `yaml:"buffers"`
-	Helm                   *OrganizationHelmConfig `yaml:"helm"`
+	DomainName             string                           `yaml:"domainName"`
+	TlsCertificateProvider TlsCertificateProvider           `yaml:"tlsCertificateProvider"`
+	AccessControl          *OrganizationAccessControlConfig `yaml:"accessControl"`
+	Buffers                *BuffersConfig                   `yaml:"buffers"`
+	Helm                   *OrganizationHelmConfig          `yaml:"helm"`
 }
 
 type StandaloneAccessControlConfig struct {
 	install.ConfigFileCommon `yaml:",inline"`
 	*AccessControlConfig     `yaml:",inline"`
+}
+
+type OrganizationAccessControlConfig struct {
+	AccessControlConfig `yaml:",inline"`
+	MiseImage           string `yaml:"miseImage"` // Microsoft-internal access control validation sidecar. Only on internal deployments.
 }
 
 type AccessControlConfig struct {
@@ -390,14 +395,16 @@ func RenderConfig(templateValues ConfigTemplateValues, writer io.Writer) error {
 				Api: &OrganizationApiConfig{
 					DomainName:             templateValues.DomainName,
 					TlsCertificateProvider: TlsCertificateProviderLetsEncrypt,
-					AccessControl: &AccessControlConfig{
-						TenantID:  templateValues.OrganizationTenantId,
-						ApiAppUri: "api://tyger-server",
-						CliAppUri: "api://tyger-cli",
-						RoleAssignments: &TygerRbacRoleAssignments{
-							Owner: []TygerRbacRoleAssignment{
-								{
-									Principal: templateValues.TygerPrincipal,
+					AccessControl: &OrganizationAccessControlConfig{
+						AccessControlConfig: AccessControlConfig{
+							TenantID:  templateValues.OrganizationTenantId,
+							ApiAppUri: "api://tyger-server",
+							CliAppUri: "api://tyger-cli",
+							RoleAssignments: &TygerRbacRoleAssignments{
+								Owner: []TygerRbacRoleAssignment{
+									{
+										Principal: templateValues.TygerPrincipal,
+									},
 								},
 							},
 						},

--- a/cli/internal/install/cloudinstall/helm.go
+++ b/cli/internal/install/cloudinstall/helm.go
@@ -613,6 +613,7 @@ func (inst *Installer) InstallTygerHelmChart(ctx context.Context, org *Organizat
 			"containerRegistryProxy": inst.Config.Cloud.Compute.ContainerRegistryProxy,
 			"accessControl": map[string]any{
 				"enabled":   true,
+				"tenantId":  org.Api.AccessControl.TenantID,
 				"authority": cloud.AzurePublic.ActiveDirectoryAuthorityHost + org.Api.AccessControl.TenantID,
 				"audience":  org.Api.AccessControl.ApiAppUri,
 				"apiAppId":  org.Api.AccessControl.ApiAppId,
@@ -642,6 +643,13 @@ func (inst *Installer) InstallTygerHelmChart(ctx context.Context, org *Organizat
 			},
 			"clusterConfiguration": clustersConfig,
 		},
+	}
+
+	if org.Api.AccessControl.MiseImage != "" {
+		helmConfig.Values["accessControl"].(map[string]any)["mise"] = map[string]any{
+			"enabled": true,
+			"image":   org.Api.AccessControl.MiseImage,
+		}
 	}
 
 	var overrides *HelmChartConfig

--- a/cli/internal/install/cloudinstall/validation.go
+++ b/cli/internal/install/cloudinstall/validation.go
@@ -519,7 +519,7 @@ func quickValidateApiConfig(ctx context.Context, success *bool, config *CloudEnv
 	if apiConfig.AccessControl == nil {
 		validationError(ctx, success, "The `api.accessControl` field is required for organization '%s'", org.Name)
 	} else {
-		quickValidateAccessControlConfig(ctx, success, apiConfig.AccessControl, org)
+		quickValidateAccessControlConfig(ctx, success, &apiConfig.AccessControl.AccessControlConfig, org)
 	}
 
 	if apiConfig.Buffers == nil {

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -226,6 +226,8 @@ organizations:
               objectId: 15bf92f7-9210-480f-a6ad-8d576d0baac7
               displayName: tyger-client-contributor
 
+        miseImage: eminence.azurecr.io/mise-sidecar:dev-1-37-0
+
       buffers:
         # TTL for active buffers before they are automatically soft-deleted (D.HH:MM:SS) (0 = never expire)
         activeLifetime: 0.00:00

--- a/deploy/helm/tyger/templates/server.yaml
+++ b/deploy/helm/tyger/templates/server.yaml
@@ -132,6 +132,10 @@ spec:
               value: {{ required "When accessControl.enabled is true, a value for accessControl.cliAppUri is required" .Values.accessControl.cliAppUri }}
             - name: AccessControl__CliAppId
               value: {{ required "When accessControl.enabled is true, a value for accessControl.cliAppId is required" .Values.accessControl.cliAppId }}
+            {{- if (and .Values.accessControl.mise .Values.accessControl.mise.enabled) }}
+            - name: AccessControl__UseMiseSidecar
+              value: "true"
+            {{- end}}
           {{- end }}
             - name: Compute__Kubernetes__Namespace
               value: {{ .Release.Namespace }}
@@ -211,6 +215,43 @@ spec:
             httpGet:
               path: /healthcheck
               port: 5000
+
+        {{- if (and .Values.accessControl.mise .Values.accessControl.mise.enabled) }}
+        # The mise-sidecar container is only used for Microsoft internal environments.
+        # It performs additional OAuth token validation.
+        - name: mise-sidecar
+          image: {{ .Values.accessControl.mise.image }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          ports:
+            - containerPort: 4000
+          env:
+            - name: MISE_CONTAINER_Kestrel__Endpoints__Http__url
+              value: http://+:4000
+            - name: Logging__Console__FormatterName
+              value: json
+            - name: MISE_CONTAINER_AzureAd__TenantId
+              value: {{ .Values.accessControl.tenantId }}
+            - name: MISE_CONTAINER_AzureAd__ClientId
+              value: {{ .Values.accessControl.apiAppId }}
+            - name: MISE_CONTAINER_AzureAd__Audience
+              value: {{ .Values.accessControl.apiAppId }}
+            - name: MISE_CONTAINER_AzureAd__InboundPolicies__0__Label
+              value: "inbound-policy"
+            - name: MISE_CONTAINER_AzureAd__InboundPolicies__0__AuthenticationSchemes__0
+              value: "Bearer"
+            - name: MISE_CONTAINER_AzureAd__InboundPolicies__0__ValidAudiences__0
+              value: {{ .Values.accessControl.apiAppId }}
+            - name: MISE_CONTAINER_AzureAd__InboundPolicies__0__ValidAudiences__1
+              value: {{ .Values.accessControl.apiAppUri }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 4000
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 4000
+        {{- end }}
 
       serviceAccount: {{ .Values.identity.tygerServer.name }}
       {{- with .Values.nodeSelector }}

--- a/deploy/helm/tyger/values.yaml
+++ b/deploy/helm/tyger/values.yaml
@@ -22,6 +22,7 @@ identity:
 
 accessControl:
   enabled: true
+  tenantId:
   authority:
   audience:
   apiAppUri:

--- a/server/ControlPlane/AccessControl/AccessControl.cs
+++ b/server/ControlPlane/AccessControl/AccessControl.cs
@@ -95,11 +95,7 @@ public static class AccessControl
                 jwtOptions.Authority = accessControlOptions.Value.Authority + "/v2.0";
                 jwtOptions.Audience = accessControlOptions.Value.ApiAppId;
                 jwtOptions.Challenge = $"Bearer authority={accessControlOptions.Value.Authority}, audience={accessControlOptions.Value.Audience}";
-                jwtOptions.Events = new JwtBearerEvents
-                {
-                    OnForbidden = OnForbidden,
-                    OnTokenValidated = accessControlOptions.Value.UseMiseSidecar ? (context) => context.HttpContext.RequestServices.GetRequiredService<MiseSidecarClient>().ValidateWithMiseSidecar(context) : Task.CompletedTask
-                };
+                jwtOptions.Events = new JwtBearerEvents { OnForbidden = OnForbidden, };
                 if (accessControlOptions.Value.UseMiseSidecar)
                 {
                     MiseSidecarClient? miseSidecarClient = null;

--- a/server/ControlPlane/AccessControl/AccessControl.cs
+++ b/server/ControlPlane/AccessControl/AccessControl.cs
@@ -68,27 +68,43 @@ public static class AccessControl
             .AddJwtBearer(EntraV1Scheme)
             .AddJwtBearer(EntraV2Scheme);
 
-        builder.Services.AddOptions<JwtBearerOptions>(EntraV1Scheme).Configure<IOptions<AccessControlOptions>>((jwtOptions, securityConfiguration) =>
+        builder.Services.AddSingleton<MiseSidecarClient>();
+
+        builder.Services.AddOptions<JwtBearerOptions>(EntraV1Scheme).Configure<IOptions<AccessControlOptions>>((jwtOptions, accessControlOptions) =>
         {
-            if (securityConfiguration.Value.Enabled)
+            if (accessControlOptions.Value.Enabled)
             {
                 // Tokens using the v1 format use the v1.0 endpoint
-                jwtOptions.Authority = securityConfiguration.Value.Authority;
-                jwtOptions.Audience = securityConfiguration.Value.Audience;
-                jwtOptions.Challenge = $"Bearer authority={securityConfiguration.Value.Authority}, audience={securityConfiguration.Value.Audience}";
-                jwtOptions.Events = new() { OnForbidden = OnForbidden };
+                jwtOptions.Authority = accessControlOptions.Value.Authority;
+                jwtOptions.Audience = accessControlOptions.Value.Audience;
+                jwtOptions.Challenge = $"Bearer authority={accessControlOptions.Value.Authority}, audience={accessControlOptions.Value.Audience}";
+                jwtOptions.Events = new JwtBearerEvents { OnForbidden = OnForbidden };
+                if (accessControlOptions.Value.UseMiseSidecar)
+                {
+                    MiseSidecarClient? miseSidecarClient = null;
+                    jwtOptions.Events.OnTokenValidated = context => (miseSidecarClient ??= context.HttpContext.RequestServices.GetRequiredService<MiseSidecarClient>()).ValidateWithMiseSidecar(context);
+                }
             }
         });
 
-        builder.Services.AddOptions<JwtBearerOptions>(EntraV2Scheme).Configure<IOptions<AccessControlOptions>>((jwtOptions, securityConfiguration) =>
+        builder.Services.AddOptions<JwtBearerOptions>(EntraV2Scheme).Configure<IOptions<AccessControlOptions>>((jwtOptions, accessControlOptions) =>
         {
-            if (securityConfiguration.Value.Enabled)
+            if (accessControlOptions.Value.Enabled)
             {
                 // Tokens using the v2 format use the v2.0 endpoint
-                jwtOptions.Authority = securityConfiguration.Value.Authority + "/v2.0";
-                jwtOptions.Audience = securityConfiguration.Value.ApiAppId;
-                jwtOptions.Challenge = $"Bearer authority={securityConfiguration.Value.Authority}, audience={securityConfiguration.Value.Audience}";
-                jwtOptions.Events = new() { OnForbidden = OnForbidden };
+                jwtOptions.Authority = accessControlOptions.Value.Authority + "/v2.0";
+                jwtOptions.Audience = accessControlOptions.Value.ApiAppId;
+                jwtOptions.Challenge = $"Bearer authority={accessControlOptions.Value.Authority}, audience={accessControlOptions.Value.Audience}";
+                jwtOptions.Events = new JwtBearerEvents
+                {
+                    OnForbidden = OnForbidden,
+                    OnTokenValidated = accessControlOptions.Value.UseMiseSidecar ? (context) => context.HttpContext.RequestServices.GetRequiredService<MiseSidecarClient>().ValidateWithMiseSidecar(context) : Task.CompletedTask
+                };
+                if (accessControlOptions.Value.UseMiseSidecar)
+                {
+                    MiseSidecarClient? miseSidecarClient = null;
+                    jwtOptions.Events.OnTokenValidated = context => (miseSidecarClient ??= context.HttpContext.RequestServices.GetRequiredService<MiseSidecarClient>()).ValidateWithMiseSidecar(context);
+                }
             }
         });
 
@@ -177,6 +193,7 @@ public class AccessControlOptions : IValidatableObject
     public string? ApiAppId { get; init; }
     public string? CliAppUri { get; init; }
     public string? CliAppId { get; init; }
+    public bool UseMiseSidecar { get; init; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/server/ControlPlane/AccessControl/LoggerExtensions.cs
+++ b/server/ControlPlane/AccessControl/LoggerExtensions.cs
@@ -7,4 +7,7 @@ public static partial class LogingExtensions
 {
     [LoggerMessage(LogLevel.Critical, "Missing authorization specification on {endpointDisplayName}")]
     public static partial void AuthorizationNotSpecifiedOnEndpoint(this ILogger logger, string endpointDisplayName);
+
+    [LoggerMessage(LogLevel.Information, "MISE authentication denied: {reason}")]
+    public static partial void MiseAuthentationDenied(this ILogger logger, string reason);
 }

--- a/server/ControlPlane/AccessControl/MiseSidecarClient.cs
+++ b/server/ControlPlane/AccessControl/MiseSidecarClient.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Net.Http.Headers;
+
+namespace Tyger.ControlPlane.AccessControl;
+
+/// <summary>
+/// Calls into a sidecar to perform additional authorization checks.
+/// Only used on Microsoft internal deployments.
+/// </summary>
+internal sealed class MiseSidecarClient : IDisposable
+{
+    private const string SidecarEndpointAddress = "http://localhost:4000/ValidateRequest";
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<MiseSidecarClient> _logger;
+
+    public MiseSidecarClient(ILogger<MiseSidecarClient> logger)
+    {
+        _httpClient = new HttpClient();
+        _logger = logger;
+    }
+
+    public async Task ValidateWithMiseSidecar(TokenValidatedContext context)
+    {
+        var originalRequest = context.HttpContext.Request;
+        string originalUri = $"{originalRequest.Scheme}://{originalRequest.Host}{originalRequest.Path}{originalRequest.QueryString}";
+        string originalMethod = originalRequest.Method;
+        string originalIp = context.HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+        string originalAuthHeader = originalRequest.Headers[HeaderNames.Authorization].ToString() ?? string.Empty;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, SidecarEndpointAddress);
+
+        request.Headers.TryAddWithoutValidation("Original-Uri", originalUri);
+        request.Headers.TryAddWithoutValidation("Original-Method", originalMethod);
+        request.Headers.TryAddWithoutValidation("X-Forwarded-For", originalIp);
+        request.Headers.TryAddWithoutValidation("Authorization", originalAuthHeader);
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, context.HttpContext.RequestAborted);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            return;
+        }
+
+        string errorDescription = string.Empty;
+        if (response.Headers.TryGetValues("Error-Description", out var errorDescVals))
+        {
+            errorDescription = string.Join("; ", errorDescVals);
+        }
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            _logger.MiseAuthentationDenied(errorDescription);
+            context.Fail(string.IsNullOrEmpty(errorDescription) ? "Token validation failed." : errorDescription);
+            return;
+        }
+
+        throw new InvalidOperationException($"MISE sidecar returned unexpected status code: {(int)response.StatusCode} with error description: {errorDescription}");
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}


### PR DESCRIPTION
Microsoft tenants are required to use MISE to perform token validation. For internal environments, we deploy a sidecar container and call into it to perform the additional token validation.