### PR TITLE
Allow service tags to be specified on public IP addresses

### DIFF
--- a/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
+++ b/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
@@ -106,6 +106,23 @@ cloud:
             # osSku: defaults to AzureLinux
             {{- end }}
           {{- end }}
+
+        {{- if .InboundIpServiceTags }}
+
+        inboundIpServiceTags:
+            {{- range .InboundIpServiceTags }}
+            - type: {{ .Type }}
+              tag: {{ .Tag }}
+            {{- end }}
+        {{- end }}
+        {{- if .OutboundIpServiceTags }}
+
+        outboundIpServiceTags:
+          {{- range .OutboundIpServiceTags }}
+          - type: {{ .Type }}
+            tag: {{ .Tag }}
+          {{- end }}
+        {{- end }}
     {{- end }}
 
     # These are the principals that will have the ability to run `tyger api install`.

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -159,18 +159,25 @@ func (c *ComputeConfig) GetApiHostCluster() *ClusterConfig {
 	panic("API host cluster not found - this should have been caught during validation")
 }
 
+type IpServiceTag struct {
+	Type string `yaml:"type"`
+	Tag  string `yaml:"tag"`
+}
+
 type ClusterConfig struct {
-	Name              string                                    `yaml:"name"`
-	ApiHost           bool                                      `yaml:"apiHost"`
-	Location          string                                    `yaml:"location"`
-	Sku               armcontainerservice.ManagedClusterSKUTier `yaml:"sku"`
-	KubernetesVersion string                                    `yaml:"kubernetesVersion,omitempty"`
-	ExistingSubnet    *SubnetReference                          `yaml:"existingSubnet,omitempty"`
-	SystemNodePool    *NodePoolConfig                           `yaml:"systemNodePool"`
-	UserNodePools     []*NodePoolConfig                         `yaml:"userNodePools"`
-	PodCidr           string                                    `yaml:"podCidr,omitempty"`
-	ServiceCidr       string                                    `yaml:"serviceCidr,omitempty"`
-	DnsServiceIp      string                                    `yaml:"dnsServiceIp,omitempty"`
+	Name                  string                                    `yaml:"name"`
+	ApiHost               bool                                      `yaml:"apiHost"`
+	Location              string                                    `yaml:"location"`
+	Sku                   armcontainerservice.ManagedClusterSKUTier `yaml:"sku"`
+	KubernetesVersion     string                                    `yaml:"kubernetesVersion,omitempty"`
+	ExistingSubnet        *SubnetReference                          `yaml:"existingSubnet,omitempty"`
+	SystemNodePool        *NodePoolConfig                           `yaml:"systemNodePool"`
+	UserNodePools         []*NodePoolConfig                         `yaml:"userNodePools"`
+	PodCidr               string                                    `yaml:"podCidr,omitempty"`
+	ServiceCidr           string                                    `yaml:"serviceCidr,omitempty"`
+	DnsServiceIp          string                                    `yaml:"dnsServiceIp,omitempty"`
+	InboundIpServiceTags  []IpServiceTag                            `yaml:"inboundIpServiceTags,omitempty"`
+	OutboundIpServiceTags []IpServiceTag                            `yaml:"outboundIpServiceTags,omitempty"`
 }
 
 type SubnetReference struct {

--- a/cli/internal/install/cloudinstall/storage.go
+++ b/cli/internal/install/cloudinstall/storage.go
@@ -32,7 +32,7 @@ func (inst *Installer) CreateStorageAccount(ctx context.Context,
 	if resp, err := storageClient.GetProperties(ctx, resourceGroupName, storageAccountConfig.Name, nil); err == nil {
 		if existingTag, ok := resp.Tags[TagKey]; ok {
 			if *existingTag != inst.Config.EnvironmentName {
-				return nil, fmt.Errorf("storage account '%s' is already in use by enrironment '%s'", storageAccountConfig.Name, *existingTag)
+				return nil, fmt.Errorf("storage account '%s' is already in use by environment '%s'", storageAccountConfig.Name, *existingTag)
 			}
 			tags = resp.Tags
 		}

--- a/deploy/config/microsoft/cloudconfig-private-link.yml
+++ b/deploy/config/microsoft/cloudconfig-private-link.yml
@@ -214,6 +214,8 @@ organizations:
               objectId: 15bf92f7-9210-480f-a6ad-8d576d0baac7
               displayName: tyger-client-contributor
 
+        miseImage: eminence.azurecr.io/mise-sidecar:dev-1-37-0
+
       buffers:
         # TTL for active buffers before they are automatically soft-deleted (D.HH:MM:SS) (0 = never expire)
         activeLifetime: 0.00:00

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -76,6 +76,14 @@ cloud:
             maxCount: 10
             # osSku: defaults to AzureLinux
 
+        inboundIpServiceTags:
+            - type: FirstPartyUsage
+              tag: /NonProd
+
+        outboundIpServiceTags:
+          - type: FirstPartyUsage
+            tag: /NonProd
+
     # These are the principals that will have the ability to run `tyger api install`.
     # They will have access to the "tyger" namespace in each cluster and will have
     # the necessary Azure RBAC role assignments.


### PR DESCRIPTION
Allow custom service tags to be set on public IP addresses. Changing these results in a redeployment of  Traefik and will cause downtime.