### PR TITLE
Add service tags to private cluster's outbound IP

### DIFF
--- a/deploy/config/microsoft/cloudconfig-private-link.yml
+++ b/deploy/config/microsoft/cloudconfig-private-link.yml
@@ -71,6 +71,10 @@ cloud:
             maxCount: 10
             # osSku: defaults to AzureLinux
 
+        outboundIpServiceTags:
+          - type: FirstPartyUsage
+            tag: /NonProd
+
     # These are the principals that will have the ability to run `tyger api install`.
     # They will have access to the "tyger" namespace in each cluster and will have
     # the necessary Azure RBAC role assignments.


### PR DESCRIPTION
In #261, I forgot to add tags to the outbound public IP address for the private cluster.