### PR TITLE
Ensure Traefik reloads TLS cert when it is changed

### DIFF
--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -633,7 +633,7 @@ func clusterNeedsUpdating(cluster, existingCluster armcontainerservice.ManagedCl
 					return true, false
 				}
 
-				if np.OSSKU != existingNp.OSSKU {
+				if *np.OSSKU != *existingNp.OSSKU {
 					return true, false
 				}
 


### PR DESCRIPTION
Traefik does not watch the TLS certificate file, but it does watch the config file, so we touch the config file when we detect that the cert file has changed.