### PR TITLE
Support custom resource tags

### DIFF
--- a/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
+++ b/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
@@ -8,6 +8,17 @@ cloud:
   resourceGroup: {{ .ResourceGroup }}
   defaultLocation: {{ .DefaultLocation}}
 
+  # Tags to apply to all resources and resource groups
+  {{- if not .ResourceTags }}
+  # resourceTags:
+  #   mytag: myvalue
+  {{- else  }}
+  resourceTags:
+  {{- range $k, $v := .ResourceTags }}
+    {{ $k }}: {{ $v }}
+  {{- end }}
+  {{- end }}
+
   # Whether to use private networking. The default is false.
   # If true, Tyger service, storage storage accounts, and all other created resources
   # will not be accessible from the public internet.

--- a/cli/internal/install/cloudinstall/cloud.go
+++ b/cli/internal/install/cloudinstall/cloud.go
@@ -393,19 +393,45 @@ func (inst *Installer) ensureResourceGroupCreated(ctx context.Context, name stri
 		return fmt.Errorf("failed to create resource groups client: %w", err)
 	}
 
-	resp, err := c.CheckExistence(ctx, name, nil)
-	if err != nil {
-		return fmt.Errorf("failed to check resource group existence: %w", err)
+	var existingResouceGroup *armresources.ResourceGroup
+	if resp, err := c.Get(ctx, name, nil); err != nil {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) || respErr.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("failed to get resource group: %w", err)
+		}
+	} else {
+		existingResouceGroup = &resp.ResourceGroup
 	}
 
-	if resp.Success {
+	var tags map[string]*string
+	if len(inst.Config.Cloud.ResourceTags) > 0 {
+		if existingResouceGroup != nil && existingResouceGroup.Tags != nil {
+			tags = existingResouceGroup.Tags
+		} else {
+			tags = make(map[string]*string)
+		}
+
+		tagsChanged := false
+		for k, v := range inst.Config.Cloud.ResourceTags {
+			if existingVal, ok := tags[k]; ok && existingVal != nil && *existingVal == v {
+				continue
+			}
+			tagsChanged = true
+			tags[k] = &v
+		}
+
+		if !tagsChanged && existingResouceGroup != nil {
+			return nil
+		}
+	} else if existingResouceGroup != nil {
 		return nil
 	}
 
-	log.Debug().Msgf("Creating resource group '%s'", name)
+	log.Debug().Msgf("Creating or updating resource group '%s'", name)
 	_, err = c.CreateOrUpdate(ctx, name,
 		armresources.ResourceGroup{
 			Location: Ptr(inst.Config.Cloud.DefaultLocation),
+			Tags:     tags,
 		}, nil)
 
 	if err != nil {

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -68,6 +68,7 @@ type CloudConfig struct {
 	SubscriptionID        string                `yaml:"subscriptionId"`
 	DefaultLocation       string                `yaml:"defaultLocation"`
 	ResourceGroup         string                `yaml:"resourceGroup"`
+	ResourceTags          map[string]string     `yaml:"resourceTags"`
 	PrivateNetworking     bool                  `yaml:"privateNetworking"`
 	Compute               *ComputeConfig        `yaml:"compute"`
 	Database              *DatabaseServerConfig `yaml:"database"`

--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -74,6 +74,9 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 	}
 
 	tags[TagKey] = &inst.Config.EnvironmentName
+	for k, v := range inst.Config.Cloud.ResourceTags {
+		tags[k] = &v
+	}
 
 	clustersClient, err := armcontainerservice.NewManagedClustersClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
 	if err != nil {
@@ -509,6 +512,9 @@ func (inst *Installer) createOutboundIpAddress(ctx context.Context, cluster *Clu
 		azureTags = make(map[string]*string)
 	}
 	azureTags[TagKey] = &inst.Config.EnvironmentName
+	for k, v := range inst.Config.Cloud.ResourceTags {
+		azureTags[k] = &v
+	}
 
 	ipTags := []*armnetwork.IPTag{}
 	for _, t := range cluster.OutboundIpServiceTags {
@@ -633,7 +639,7 @@ func clusterNeedsUpdating(cluster, existingCluster armcontainerservice.ManagedCl
 					return true, false
 				}
 
-				if np.OSSKU != existingNp.OSSKU {
+				if *np.OSSKU != *existingNp.OSSKU {
 					return true, false
 				}
 

--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -639,7 +639,7 @@ func clusterNeedsUpdating(cluster, existingCluster armcontainerservice.ManagedCl
 					return true, false
 				}
 
-				if *np.OSSKU != *existingNp.OSSKU {
+				if np.OSSKU != existingNp.OSSKU {
 					return true, false
 				}
 

--- a/cli/internal/install/cloudinstall/database.go
+++ b/cli/internal/install/cloudinstall/database.go
@@ -83,6 +83,9 @@ func (inst *Installer) createDatabaseServer(ctx context.Context) (any, error) {
 		tags = make(map[string]*string)
 	}
 	tags[TagKey] = &inst.Config.EnvironmentName
+	for k, v := range inst.Config.Cloud.ResourceTags {
+		tags[k] = &v
+	}
 	if instanceKey := tags[dbServerInstanceTagKey]; instanceKey == nil || *instanceKey == "" {
 		tags[dbServerInstanceTagKey] = Ptr(uuid.NewString())
 	}

--- a/cli/internal/install/cloudinstall/mi.go
+++ b/cli/internal/install/cloudinstall/mi.go
@@ -77,6 +77,9 @@ func (inst *Installer) createManagedIdentity(ctx context.Context, name string, r
 	}
 
 	tags[TagKey] = &inst.Config.EnvironmentName
+	for k, v := range inst.Config.Cloud.ResourceTags {
+		tags[k] = &v
+	}
 
 	resp, err := identitiesClient.CreateOrUpdate(ctx, resourceGroup, name, armmsi.Identity{
 		Location: &inst.Config.Cloud.DefaultLocation,

--- a/cli/internal/install/cloudinstall/storage.go
+++ b/cli/internal/install/cloudinstall/storage.go
@@ -42,6 +42,9 @@ func (inst *Installer) CreateStorageAccount(ctx context.Context,
 		tags = make(map[string]*string)
 	}
 	tags[TagKey] = &inst.Config.EnvironmentName
+	for k, v := range inst.Config.Cloud.ResourceTags {
+		tags[k] = &v
+	}
 
 	parameters := armstorage.AccountCreateParameters{
 		Tags:     tags,

--- a/deploy/config/microsoft/cloudconfig-private-link.yml
+++ b/deploy/config/microsoft/cloudconfig-private-link.yml
@@ -7,6 +7,10 @@ cloud:
   resourceGroup: ${TYGER_ENVIRONMENT_NAME}
   defaultLocation: ${TYGER_LOCATION}
 
+  # Tags to apply to all resources and resource groups
+  resourceTags:
+    tyger-development: "true"
+
   # Whether to use private networking. The default is false.
   # If true, Tyger service, storage storage accounts, and all other created resources
   # will not be accessible from the public internet.
@@ -130,6 +134,9 @@ cloud:
     # Firewall rules to control where the database can be accessed from,
     # in addition to the control-plane cluster.
     firewallRules: ${TYGER_ENVIRONMENT_FIREWALL_RULES}
+
+  # Tags to apply to all resources and resource groups
+  resourceTags:
 
 organizations:
   - name: lamna

--- a/deploy/config/microsoft/cloudconfig-private-link.yml
+++ b/deploy/config/microsoft/cloudconfig-private-link.yml
@@ -135,9 +135,6 @@ cloud:
     # in addition to the control-plane cluster.
     firewallRules: ${TYGER_ENVIRONMENT_FIREWALL_RULES}
 
-  # Tags to apply to all resources and resource groups
-  resourceTags:
-
 organizations:
   - name: lamna
     cloud:

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -7,6 +7,10 @@ cloud:
   resourceGroup: ${TYGER_ENVIRONMENT_NAME}
   defaultLocation: ${TYGER_LOCATION}
 
+  # Tags to apply to all resources and resource groups
+  resourceTags:
+    tyger-development: "true"
+
   # Whether to use private networking. The default is false.
   # If true, Tyger service, storage storage accounts, and all other created resources
   # will not be accessible from the public internet.

--- a/docs/introduction/installation/cloud-installation.md
+++ b/docs/introduction/installation/cloud-installation.md
@@ -62,6 +62,10 @@ cloud:
   resourceGroup: demo
   defaultLocation: westus2
 
+  # Tags to apply to all resources and resource groups
+  # resourceTags:
+  #   mytag: myvalue
+
   # Whether to use private networking. The default is false.
   # If true, Tyger service, storage storage accounts, and all other created resources
   # will not be accessible from the public internet.


### PR DESCRIPTION
Adding `cloud.resourceTags` to the cloud config file. These tags will be applied to all resource groups, including those created by AKS.