### PR TITLE
Support configurable AKS cluster outbound type

### DIFF
--- a/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
+++ b/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
@@ -116,6 +116,12 @@ cloud:
         # It must be within the service address range specified in serviceCidr.
         {{ optionalField "dnsServiceIp" .DnsServiceIp (printf "defaults to %s" (DefaultDnsServiceIp)) }}
 
+        # The outbound (egress) routing method.
+        # Supported values: loadBalancer (default), managedNATGateway, userDefinedRouting.
+        # userDefinedRouting requires existingSubnet with a route table directing traffic to a firewall/NVA.
+        # outboundIpServiceTags can only be used with loadBalancer.
+        {{ optionalField "outboundType" (printf "%s" .OutboundType) "defaults to loadBalancer" }}
+
         systemNodePool:
           name: {{ .SystemNodePool.Name }}
           vmSize: {{ .SystemNodePool.VMSize }}

--- a/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
+++ b/cli/internal/install/cloudinstall/cloud-config-pretty.tpl
@@ -117,7 +117,7 @@ cloud:
         {{ optionalField "dnsServiceIp" .DnsServiceIp (printf "defaults to %s" (DefaultDnsServiceIp)) }}
 
         # The outbound (egress) routing method.
-        # Supported values: loadBalancer (default), managedNATGateway, userDefinedRouting.
+        # Supported values: loadBalancer (default), userDefinedRouting.
         # userDefinedRouting requires existingSubnet with a route table directing traffic to a firewall/NVA.
         # outboundIpServiceTags can only be used with loadBalancer.
         {{ optionalField "outboundType" (printf "%s" .OutboundType) "defaults to loadBalancer" }}

--- a/cli/internal/install/cloudinstall/cloud.go
+++ b/cli/internal/install/cloudinstall/cloud.go
@@ -668,3 +668,10 @@ func getResourceGroupFromID(resourceID string) string {
 func Ptr[T any](t T) *T {
 	return &t
 }
+
+func ptrChanged[T comparable](a, b *T) bool {
+	if a == nil {
+		return b != nil
+	}
+	return b == nil || *a != *b
+}

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -184,6 +184,7 @@ type ClusterConfig struct {
 	PodCidr               string                                    `yaml:"podCidr,omitempty"`
 	ServiceCidr           string                                    `yaml:"serviceCidr,omitempty"`
 	DnsServiceIp          string                                    `yaml:"dnsServiceIp,omitempty"`
+	OutboundType          armcontainerservice.OutboundType          `yaml:"outboundType,omitempty"`
 	InboundIpServiceTags  []IpServiceTag                            `yaml:"inboundIpServiceTags,omitempty"`
 	OutboundIpServiceTags []IpServiceTag                            `yaml:"outboundIpServiceTags,omitempty"`
 }

--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const DefaultKubernetesVersion = "1.33"
+const DefaultKubernetesVersion = "1.34"
 const DefaultPodCidr = "10.244.0.0/16"
 const DefaultServiceCidr = "10.0.0.0/16"
 const DefaultDnsServiceIp = "10.0.0.10"
@@ -47,9 +47,13 @@ func (inst *Installer) getCluster(ctx context.Context, clusterConfig *ClusterCon
 }
 
 func (inst *Installer) createCluster(ctx context.Context, clusterConfig *ClusterConfig) (*armcontainerservice.ManagedCluster, error) {
-	outboundIpAddress, err := inst.createOutboundIpAddress(ctx, clusterConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create outbound IP address: %w", err)
+	var outboundIpAddress *armnetwork.PublicIPAddress
+	if clusterConfig.OutboundType == armcontainerservice.OutboundTypeLoadBalancer {
+		var err error
+		outboundIpAddress, err = inst.createOutboundIpAddress(ctx, clusterConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create outbound IP address: %w", err)
+		}
 	}
 
 	var tags map[string]*string
@@ -130,7 +134,7 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 				},
 			},
 			NetworkProfile: &armcontainerservice.NetworkProfile{
-				LoadBalancerProfile: &armcontainerservice.ManagedClusterLoadBalancerProfile{},
+				OutboundType: Ptr(clusterConfig.OutboundType),
 			},
 		},
 		SKU: &armcontainerservice.ManagedClusterSKU{
@@ -156,9 +160,12 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 		}
 	}
 
-	if outboundIpAddress != nil {
-		cluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs = &armcontainerservice.ManagedClusterLoadBalancerProfileOutboundIPs{
-			PublicIPs: []*armcontainerservice.ResourceReference{{ID: outboundIpAddress.ID}},
+	if clusterConfig.OutboundType == armcontainerservice.OutboundTypeLoadBalancer {
+		cluster.Properties.NetworkProfile.LoadBalancerProfile = &armcontainerservice.ManagedClusterLoadBalancerProfile{}
+		if outboundIpAddress != nil {
+			cluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs = &armcontainerservice.ManagedClusterLoadBalancerProfileOutboundIPs{
+				PublicIPs: []*armcontainerservice.ResourceReference{{ID: outboundIpAddress.ID}},
+			}
 		}
 	}
 
@@ -637,18 +644,15 @@ func clusterNeedsUpdating(cluster, existingCluster armcontainerservice.ManagedCl
 	}
 
 	if cluster.Properties.APIServerAccessProfile != nil {
-		if (cluster.Properties.APIServerAccessProfile.EnablePrivateCluster == nil) != (existingCluster.Properties.APIServerAccessProfile.EnablePrivateCluster == nil) ||
-			(cluster.Properties.APIServerAccessProfile.EnablePrivateCluster != nil && *cluster.Properties.APIServerAccessProfile.EnablePrivateCluster != *existingCluster.Properties.APIServerAccessProfile.EnablePrivateCluster) {
+		if ptrChanged(cluster.Properties.APIServerAccessProfile.EnablePrivateCluster, existingCluster.Properties.APIServerAccessProfile.EnablePrivateCluster) {
 			return true, false
 		}
 
-		if (cluster.Properties.APIServerAccessProfile.PrivateDNSZone == nil) != (existingCluster.Properties.APIServerAccessProfile.PrivateDNSZone == nil) ||
-			(cluster.Properties.APIServerAccessProfile.PrivateDNSZone != nil && *cluster.Properties.APIServerAccessProfile.PrivateDNSZone != *existingCluster.Properties.APIServerAccessProfile.PrivateDNSZone) {
+		if ptrChanged(cluster.Properties.APIServerAccessProfile.PrivateDNSZone, existingCluster.Properties.APIServerAccessProfile.PrivateDNSZone) {
 			return true, false
 		}
 
-		if (cluster.Properties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN == nil) != (existingCluster.Properties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN == nil) ||
-			(cluster.Properties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN != nil && *cluster.Properties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN != *existingCluster.Properties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN) {
+		if ptrChanged(cluster.Properties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN, existingCluster.Properties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN) {
 			return true, false
 		}
 	}
@@ -699,8 +703,7 @@ func clusterNeedsUpdating(cluster, existingCluster armcontainerservice.ManagedCl
 					}
 				}
 
-				if (np.VnetSubnetID == nil) != (existingNp.VnetSubnetID == nil) ||
-					(np.VnetSubnetID != nil && *np.VnetSubnetID != *existingNp.VnetSubnetID) {
+				if ptrChanged(np.VnetSubnetID, existingNp.VnetSubnetID) {
 					return true, false
 				}
 
@@ -746,35 +749,41 @@ func clusterNeedsUpdating(cluster, existingCluster armcontainerservice.ManagedCl
 		return true, false
 	}
 
-	if cluster.Properties.NetworkProfile.PodCidr != nil && (existingCluster.Properties.NetworkProfile.PodCidr == nil || *cluster.Properties.NetworkProfile.PodCidr != *existingCluster.Properties.NetworkProfile.PodCidr) {
+	if cluster.Properties.NetworkProfile.PodCidr != nil && ptrChanged(cluster.Properties.NetworkProfile.PodCidr, existingCluster.Properties.NetworkProfile.PodCidr) {
 		return true, false
 	}
 
-	if cluster.Properties.NetworkProfile.ServiceCidr != nil && (existingCluster.Properties.NetworkProfile.ServiceCidr == nil || *cluster.Properties.NetworkProfile.ServiceCidr != *existingCluster.Properties.NetworkProfile.ServiceCidr) {
+	if cluster.Properties.NetworkProfile.ServiceCidr != nil && ptrChanged(cluster.Properties.NetworkProfile.ServiceCidr, existingCluster.Properties.NetworkProfile.ServiceCidr) {
 		return true, false
 	}
 
-	if cluster.Properties.NetworkProfile.DNSServiceIP != nil && (existingCluster.Properties.NetworkProfile.DNSServiceIP == nil || *cluster.Properties.NetworkProfile.DNSServiceIP != *existingCluster.Properties.NetworkProfile.DNSServiceIP) {
+	if cluster.Properties.NetworkProfile.DNSServiceIP != nil && ptrChanged(cluster.Properties.NetworkProfile.DNSServiceIP, existingCluster.Properties.NetworkProfile.DNSServiceIP) {
 		return true, false
 	}
 
-	desiredOutputIpCount := 0
-	if cluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs != nil {
-		desiredOutputIpCount = len(cluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs.PublicIPs)
-	}
-
-	existingOutputIpCount := 0
-	if existingCluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs != nil {
-		existingOutputIpCount = len(existingCluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs.PublicIPs)
-	}
-
-	if desiredOutputIpCount != existingOutputIpCount ||
-		(desiredOutputIpCount > 0 &&
-			!slices.EqualFunc(
-				cluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs.PublicIPs,
-				existingCluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs.PublicIPs,
-				func(a, b *armcontainerservice.ResourceReference) bool { return *a.ID == *b.ID })) {
+	if cluster.Properties.NetworkProfile.OutboundType != nil && ptrChanged(cluster.Properties.NetworkProfile.OutboundType, existingCluster.Properties.NetworkProfile.OutboundType) {
 		return true, false
+	}
+
+	if cluster.Properties.NetworkProfile.LoadBalancerProfile != nil {
+		desiredOutputIpCount := 0
+		if cluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs != nil {
+			desiredOutputIpCount = len(cluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs.PublicIPs)
+		}
+
+		existingOutputIpCount := 0
+		if existingCluster.Properties.NetworkProfile.LoadBalancerProfile != nil && existingCluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs != nil {
+			existingOutputIpCount = len(existingCluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs.PublicIPs)
+		}
+
+		if desiredOutputIpCount != existingOutputIpCount ||
+			(desiredOutputIpCount > 0 &&
+				!slices.EqualFunc(
+					cluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs.PublicIPs,
+					existingCluster.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs.PublicIPs,
+					func(a, b *armcontainerservice.ResourceReference) bool { return *a.ID == *b.ID })) {
+			return true, false
+		}
 	}
 
 	return hasChanges, onlyScaleDown

--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -863,7 +863,7 @@ func (inst *Installer) onDeleteCluster(ctx context.Context, clusterConfig *Clust
 		}
 	}
 
-	if inst.Config.Cloud.PrivateNetworking {
+	if inst.Config.Cloud.PrivateNetworking && clusterConfig.ExistingSubnet != nil {
 
 		vnetClient, err := armnetwork.NewVirtualNetworksClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
 		if err != nil {
@@ -881,19 +881,34 @@ func (inst *Installer) onDeleteCluster(ctx context.Context, clusterConfig *Clust
 		}
 
 		if vnet != nil {
-
-			if err := removeRbacRoleAssignments(ctx, *clusterResponse.Identity.PrincipalID, *vnet.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-				return fmt.Errorf("failed to remove RBAC role assignments on VNet: %w", err)
+			var clusterPrincipalID string
+			if clusterResponse.Identity != nil {
+				if clusterResponse.Identity.PrincipalID != nil {
+					clusterPrincipalID = *clusterResponse.Identity.PrincipalID
+				} else {
+					for _, uai := range clusterResponse.Identity.UserAssignedIdentities {
+						if uai.PrincipalID != nil {
+							clusterPrincipalID = *uai.PrincipalID
+							break
+						}
+					}
+				}
 			}
-			subnetIndex := slices.IndexFunc(vnet.Properties.Subnets, func(s *armnetwork.Subnet) bool {
-				return s.Name != nil && *s.Name == clusterConfig.ExistingSubnet.SubnetName
-			})
 
-			if subnetIndex != -1 {
-				subnet := vnet.Properties.Subnets[subnetIndex]
-				if subnet.Properties.NetworkSecurityGroup != nil && subnet.Properties.NetworkSecurityGroup.ID != nil {
-					if err := removeRbacRoleAssignments(ctx, *clusterResponse.Identity.PrincipalID, *subnet.Properties.NetworkSecurityGroup.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-						return fmt.Errorf("failed to remove RBAC role assignments on subnet NSG: %w", err)
+			if clusterPrincipalID != "" {
+				if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *vnet.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
+					return fmt.Errorf("failed to remove RBAC role assignments on VNet: %w", err)
+				}
+				subnetIndex := slices.IndexFunc(vnet.Properties.Subnets, func(s *armnetwork.Subnet) bool {
+					return s.Name != nil && *s.Name == clusterConfig.ExistingSubnet.SubnetName
+				})
+
+				if subnetIndex != -1 {
+					subnet := vnet.Properties.Subnets[subnetIndex]
+					if subnet.Properties.NetworkSecurityGroup != nil && subnet.Properties.NetworkSecurityGroup.ID != nil {
+						if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *subnet.Properties.NetworkSecurityGroup.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
+							return fmt.Errorf("failed to remove RBAC role assignments on subnet NSG: %w", err)
+						}
 					}
 				}
 			}

--- a/cli/internal/install/cloudinstall/compute_test.go
+++ b/cli/internal/install/cloudinstall/compute_test.go
@@ -1,0 +1,459 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package cloudinstall
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+	"github.com/stretchr/testify/assert"
+)
+
+// baseCluster returns a minimal ManagedCluster that clusterNeedsUpdating considers up-to-date
+// when compared against itself (via a deep copy).
+func baseCluster() armcontainerservice.ManagedCluster {
+	return armcontainerservice.ManagedCluster{
+		Tags: map[string]*string{
+			"env": Ptr("test"),
+		},
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			ProvisioningState: Ptr("Succeeded"),
+			KubernetesVersion: Ptr(DefaultKubernetesVersion),
+			AutoUpgradeProfile: &armcontainerservice.ManagedClusterAutoUpgradeProfile{
+				NodeOSUpgradeChannel: Ptr(armcontainerservice.NodeOSUpgradeChannelNodeImage),
+				UpgradeChannel:       Ptr(armcontainerservice.UpgradeChannelPatch),
+			},
+			OidcIssuerProfile: &armcontainerservice.ManagedClusterOIDCIssuerProfile{
+				Enabled: Ptr(true),
+			},
+			SecurityProfile: &armcontainerservice.ManagedClusterSecurityProfile{
+				WorkloadIdentity: &armcontainerservice.ManagedClusterSecurityProfileWorkloadIdentity{
+					Enabled: Ptr(true),
+				},
+			},
+			NetworkProfile: &armcontainerservice.NetworkProfile{
+				OutboundType: Ptr(armcontainerservice.OutboundTypeLoadBalancer),
+				LoadBalancerProfile: &armcontainerservice.ManagedClusterLoadBalancerProfile{
+					OutboundIPs: &armcontainerservice.ManagedClusterLoadBalancerProfileOutboundIPs{
+						PublicIPs: []*armcontainerservice.ResourceReference{
+							{ID: Ptr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/ip1")},
+						},
+					},
+				},
+			},
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{
+					Name:                Ptr("system"),
+					VMSize:              Ptr("Standard_DS2_v2"),
+					EnableAutoScaling:   Ptr(true),
+					MinCount:            Ptr[int32](1),
+					MaxCount:            Ptr[int32](3),
+					OrchestratorVersion: Ptr(DefaultKubernetesVersion),
+					OSSKU:               Ptr(armcontainerservice.OSSKUAzureLinux),
+					Tags:                map[string]*string{"env": Ptr("test")},
+				},
+			},
+		},
+		SKU: &armcontainerservice.ManagedClusterSKU{
+			Tier: Ptr(armcontainerservice.ManagedClusterSKUTierStandard),
+		},
+	}
+}
+
+// clone returns a deep copy via JSON round-trip.
+func clone(c armcontainerservice.ManagedCluster) armcontainerservice.ManagedCluster {
+	data, err := json.Marshal(c)
+	if err != nil {
+		panic(err)
+	}
+	var cp armcontainerservice.ManagedCluster
+	if err := json.Unmarshal(data, &cp); err != nil {
+		panic(err)
+	}
+	return cp
+}
+
+func TestClusterNeedsUpdating(t *testing.T) {
+	t.Run("identical clusters", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+
+		hasChanges, onlyScaleDown := clusterNeedsUpdating(desired, existing)
+		assert.False(t, hasChanges)
+		assert.True(t, onlyScaleDown)
+	})
+
+	t.Run("provisioning not succeeded", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.ProvisioningState = Ptr("Creating")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("kubernetes version changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.KubernetesVersion = Ptr("1.32")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("node OS upgrade channel changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AutoUpgradeProfile.NodeOSUpgradeChannel = Ptr(armcontainerservice.NodeOSUpgradeChannelNone)
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("upgrade channel changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AutoUpgradeProfile.UpgradeChannel = Ptr(armcontainerservice.UpgradeChannelStable)
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("upgrade channel nil on existing", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AutoUpgradeProfile.UpgradeChannel = nil
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("tag added", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Tags["new"] = Ptr("tag")
+		existing := clone(baseCluster())
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("tag value changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Tags["env"] = Ptr("prod")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("SKU tier changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.SKU.Tier = Ptr(armcontainerservice.ManagedClusterSKUTierFree)
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("agent pool count changed", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.AgentPoolProfiles = append(desired.Properties.AgentPoolProfiles, &armcontainerservice.ManagedClusterAgentPoolProfile{
+			Name:                Ptr("user1"),
+			VMSize:              Ptr("Standard_DS2_v2"),
+			EnableAutoScaling:   Ptr(true),
+			MinCount:            Ptr[int32](0),
+			MaxCount:            Ptr[int32](5),
+			OrchestratorVersion: Ptr(DefaultKubernetesVersion),
+			OSSKU:               Ptr(armcontainerservice.OSSKUAzureLinux),
+			Tags:                map[string]*string{"env": Ptr("test")},
+		})
+		existing := clone(baseCluster())
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("API server access profile added", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.APIServerAccessProfile = &armcontainerservice.ManagedClusterAPIServerAccessProfile{
+			EnablePrivateCluster: Ptr(true),
+		}
+		existing := clone(baseCluster())
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("private cluster changed", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.APIServerAccessProfile = &armcontainerservice.ManagedClusterAPIServerAccessProfile{
+			EnablePrivateCluster:           Ptr(true),
+			EnablePrivateClusterPublicFQDN: Ptr(false),
+			PrivateDNSZone:                 Ptr("zone1"),
+		}
+		existing := clone(desired)
+		existing.Properties.APIServerAccessProfile.EnablePrivateCluster = Ptr(false)
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("private DNS zone changed", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.APIServerAccessProfile = &armcontainerservice.ManagedClusterAPIServerAccessProfile{
+			EnablePrivateCluster: Ptr(true),
+			PrivateDNSZone:       Ptr("zone-new"),
+		}
+		existing := clone(desired)
+		existing.Properties.APIServerAccessProfile.PrivateDNSZone = Ptr("zone-old")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("node pool VM size changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AgentPoolProfiles[0].VMSize = Ptr("Standard_DS3_v2")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("node pool scale down", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AgentPoolProfiles[0].MinCount = Ptr[int32](2)
+		existing.Properties.AgentPoolProfiles[0].MaxCount = Ptr[int32](5)
+
+		hasChanges, onlyScaleDown := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+		assert.True(t, onlyScaleDown)
+	})
+
+	t.Run("node pool scale up", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.AgentPoolProfiles[0].MinCount = Ptr[int32](3)
+		desired.Properties.AgentPoolProfiles[0].MaxCount = Ptr[int32](10)
+		existing := clone(baseCluster())
+
+		hasChanges, onlyScaleDown := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+		assert.False(t, onlyScaleDown)
+	})
+
+	t.Run("node pool orchestrator version changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AgentPoolProfiles[0].OrchestratorVersion = Ptr("1.32")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("node pool OSSKU changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AgentPoolProfiles[0].OSSKU = Ptr(armcontainerservice.OSSKUUbuntu)
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("node pool tag changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AgentPoolProfiles[0].Tags["env"] = Ptr("prod")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("node pool subnet changed", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.AgentPoolProfiles[0].VnetSubnetID = Ptr("/subnets/subnet1")
+		existing := clone(desired)
+		existing.Properties.AgentPoolProfiles[0].VnetSubnetID = Ptr("/subnets/subnet2")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("node pool subnet added where none", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.AgentPoolProfiles[0].VnetSubnetID = Ptr("/subnets/subnet1")
+		existing := clone(baseCluster())
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("node pool auto scaling disabled on existing", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AgentPoolProfiles[0].EnableAutoScaling = nil
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("node pool not found", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.AgentPoolProfiles[0].Name = Ptr("renamed")
+		existing := clone(baseCluster())
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("addon profile added", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.AddonProfiles = map[string]*armcontainerservice.ManagedClusterAddonProfile{
+			"omsagent": {Enabled: Ptr(true), Config: map[string]*string{"key": Ptr("val")}},
+		}
+		existing := clone(baseCluster())
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("addon profile disabled", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.AddonProfiles = map[string]*armcontainerservice.ManagedClusterAddonProfile{
+			"omsagent": {Enabled: Ptr(true), Config: map[string]*string{}},
+		}
+		existing := clone(desired)
+		existing.Properties.AddonProfiles["omsagent"].Enabled = Ptr(false)
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("addon profile config changed", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.AddonProfiles = map[string]*armcontainerservice.ManagedClusterAddonProfile{
+			"omsagent": {Enabled: Ptr(true), Config: map[string]*string{"key": Ptr("new")}},
+		}
+		existing := clone(desired)
+		existing.Properties.AddonProfiles["omsagent"].Config["key"] = Ptr("old")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("OIDC disabled on existing", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.OidcIssuerProfile.Enabled = Ptr(false)
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("workload identity disabled on existing", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.SecurityProfile.WorkloadIdentity.Enabled = Ptr(false)
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("pod CIDR changed", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.NetworkProfile.PodCidr = Ptr("10.244.0.0/16")
+		existing := clone(desired)
+		existing.Properties.NetworkProfile.PodCidr = Ptr("10.245.0.0/16")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("pod CIDR nil on desired", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.NetworkProfile.PodCidr = Ptr("10.244.0.0/16")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.False(t, hasChanges)
+	})
+
+	t.Run("service CIDR changed", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.NetworkProfile.ServiceCidr = Ptr("10.0.0.0/16")
+		existing := clone(desired)
+		existing.Properties.NetworkProfile.ServiceCidr = Ptr("10.1.0.0/16")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("DNS service IP changed", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.NetworkProfile.DNSServiceIP = Ptr("10.0.0.10")
+		existing := clone(desired)
+		existing.Properties.NetworkProfile.DNSServiceIP = Ptr("10.0.0.20")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("outbound type changed", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.NetworkProfile.OutboundType = Ptr(armcontainerservice.OutboundTypeUserDefinedRouting)
+		desired.Properties.NetworkProfile.LoadBalancerProfile = nil
+		existing := clone(baseCluster())
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("outbound type nil on desired", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.NetworkProfile.OutboundType = nil
+		existing := clone(baseCluster())
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.False(t, hasChanges)
+	})
+
+	t.Run("load balancer outbound IP changed", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs.PublicIPs[0].ID = Ptr("/publicIPAddresses/ip2")
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("load balancer outbound IP added", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.NetworkProfile.LoadBalancerProfile.OutboundIPs = nil
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+	})
+
+	t.Run("load balancer profile nil on desired", func(t *testing.T) {
+		desired := baseCluster()
+		desired.Properties.NetworkProfile.LoadBalancerProfile = nil
+		existing := clone(baseCluster())
+
+		hasChanges, _ := clusterNeedsUpdating(desired, existing)
+		assert.False(t, hasChanges)
+	})
+
+	t.Run("mixed scale up and down", func(t *testing.T) {
+		desired := baseCluster()
+		existing := clone(desired)
+		existing.Properties.AgentPoolProfiles[0].MinCount = Ptr[int32](2) // desired 1 < existing 2 → scale down
+		existing.Properties.AgentPoolProfiles[0].MaxCount = Ptr[int32](2) // desired 3 > existing 2 → scale up
+
+		hasChanges, onlyScaleDown := clusterNeedsUpdating(desired, existing)
+		assert.True(t, hasChanges)
+		assert.False(t, onlyScaleDown)
+	})
+}

--- a/cli/internal/install/cloudinstall/validation.go
+++ b/cli/internal/install/cloudinstall/validation.go
@@ -186,6 +186,28 @@ func quickValidateComputeConfig(ctx context.Context, success *bool, cloudConfig 
 			armcontainerservice.PossibleManagedClusterSKUTierValues(),
 			fmt.Sprintf("The `sku` field must be one of %%v for cluster '%s'", cluster.Name))
 
+		supportedOutboundTypes := []armcontainerservice.OutboundType{
+			armcontainerservice.OutboundTypeLoadBalancer,
+			armcontainerservice.OutboundTypeManagedNATGateway,
+			armcontainerservice.OutboundTypeUserDefinedRouting,
+		}
+
+		cluster.OutboundType = armcontainerservice.OutboundType(validateOptionalEnumField(
+			ctx,
+			success,
+			cluster.OutboundType,
+			armcontainerservice.OutboundTypeLoadBalancer,
+			supportedOutboundTypes,
+			fmt.Sprintf("The `outboundType` field must be one of %%v for cluster '%s'", cluster.Name)))
+
+		if cluster.OutboundType == armcontainerservice.OutboundTypeUserDefinedRouting && cluster.ExistingSubnet == nil {
+			validationError(ctx, success, "Since `outboundType` is `userDefinedRouting`, `existingSubnet` must be specified on cluster '%s' (the subnet must have a route table directing traffic to the firewall/NVA)", cluster.Name)
+		}
+
+		if cluster.OutboundType != armcontainerservice.OutboundTypeLoadBalancer && len(cluster.OutboundIpServiceTags) > 0 {
+			validationError(ctx, success, "`outboundIpServiceTags` can only be used when `outboundType` is `loadBalancer` on cluster '%s'", cluster.Name)
+		}
+
 		if cloudConfig.PrivateNetworking && cluster.ExistingSubnet == nil {
 			validationError(ctx, success, "Since `cloud.privateNetworking` is enabled, `existingSubnet` must be specified on cluster '%s'", cluster.Name)
 		}

--- a/cli/internal/install/cloudinstall/validation.go
+++ b/cli/internal/install/cloudinstall/validation.go
@@ -188,7 +188,6 @@ func quickValidateComputeConfig(ctx context.Context, success *bool, cloudConfig 
 
 		supportedOutboundTypes := []armcontainerservice.OutboundType{
 			armcontainerservice.OutboundTypeLoadBalancer,
-			armcontainerservice.OutboundTypeManagedNATGateway,
 			armcontainerservice.OutboundTypeUserDefinedRouting,
 		}
 

--- a/deploy/config/microsoft/cloudconfig-private-link.yml
+++ b/deploy/config/microsoft/cloudconfig-private-link.yml
@@ -46,7 +46,7 @@ cloud:
     clusters:
       - name: ${TYGER_ENVIRONMENT_NAME}
         apiHost: true
-        kubernetesVersion: "1.33"
+        kubernetesVersion: "1.34"
         sku: Standard
         # location: defaults to Standard
 
@@ -69,6 +69,12 @@ cloud:
         # The IP address assigned to the Kubernetes DNS service.
         # It must be within the service address range specified in serviceCidr.
         dnsServiceIp: 10.2.0.10
+
+        # The outbound (egress) routing method.
+        # Supported values: loadBalancer (default), managedNATGateway, userDefinedRouting.
+        # userDefinedRouting requires existingSubnet with a route table directing traffic to a firewall/NVA.
+        # outboundIpServiceTags can only be used with loadBalancer.
+        # outboundType: defaults to loadBalancer
 
         systemNodePool:
           name: system

--- a/deploy/config/microsoft/cloudconfig-private-link.yml
+++ b/deploy/config/microsoft/cloudconfig-private-link.yml
@@ -71,7 +71,7 @@ cloud:
         dnsServiceIp: 10.2.0.10
 
         # The outbound (egress) routing method.
-        # Supported values: loadBalancer (default), managedNATGateway, userDefinedRouting.
+        # Supported values: loadBalancer (default), userDefinedRouting.
         # userDefinedRouting requires existingSubnet with a route table directing traffic to a firewall/NVA.
         # outboundIpServiceTags can only be used with loadBalancer.
         # outboundType: defaults to loadBalancer

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -46,7 +46,7 @@ cloud:
     clusters:
       - name: ${TYGER_ENVIRONMENT_NAME}
         apiHost: true
-        kubernetesVersion: "1.33"
+        kubernetesVersion: "1.34"
         sku: Standard
         # location: defaults to Standard
 
@@ -69,6 +69,12 @@ cloud:
         # The IP address assigned to the Kubernetes DNS service.
         # It must be within the service address range specified in serviceCidr.
         # dnsServiceIp: defaults to 10.0.0.10
+
+        # The outbound (egress) routing method.
+        # Supported values: loadBalancer (default), managedNATGateway, userDefinedRouting.
+        # userDefinedRouting requires existingSubnet with a route table directing traffic to a firewall/NVA.
+        # outboundIpServiceTags can only be used with loadBalancer.
+        # outboundType: defaults to loadBalancer
 
         systemNodePool:
           name: systemnp

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -71,7 +71,7 @@ cloud:
         # dnsServiceIp: defaults to 10.0.0.10
 
         # The outbound (egress) routing method.
-        # Supported values: loadBalancer (default), managedNATGateway, userDefinedRouting.
+        # Supported values: loadBalancer (default), userDefinedRouting.
         # userDefinedRouting requires existingSubnet with a route table directing traffic to a firewall/NVA.
         # outboundIpServiceTags can only be used with loadBalancer.
         # outboundType: defaults to loadBalancer

--- a/docs/introduction/installation/cloud-installation.md
+++ b/docs/introduction/installation/cloud-installation.md
@@ -125,6 +125,12 @@ cloud:
         # It must be within the service address range specified in serviceCidr.
         # dnsServiceIp: defaults to 10.0.0.10
 
+        # The outbound (egress) routing method.
+        # Supported values: loadBalancer (default), managedNATGateway, userDefinedRouting.
+        # userDefinedRouting requires existingSubnet with a route table directing traffic to a firewall/NVA.
+        # outboundIpServiceTags can only be used with loadBalancer.
+        # outboundType: defaults to loadBalancer
+
         systemNodePool:
           name: system
           vmSize: Standard_DS2_v2

--- a/docs/introduction/installation/cloud-installation.md
+++ b/docs/introduction/installation/cloud-installation.md
@@ -126,7 +126,7 @@ cloud:
         # dnsServiceIp: defaults to 10.0.0.10
 
         # The outbound (egress) routing method.
-        # Supported values: loadBalancer (default), managedNATGateway, userDefinedRouting.
+        # Supported values: loadBalancer (default), userDefinedRouting.
         # userDefinedRouting requires existingSubnet with a route table directing traffic to a firewall/NVA.
         # outboundIpServiceTags can only be used with loadBalancer.
         # outboundType: defaults to loadBalancer


### PR DESCRIPTION
Tyger deployments using AKS with private networking may not want the cluster to have an outbound public IP. Instead, they route egress traffic through a firewall or NVA using a route table on the subnet (user-defined routing). This PR adds support for configuring the AKS cluster outbound type.