### PR TITLE
Harden ResourceInformer watch loop and fix onError regression

### DIFF
--- a/server/ControlPlane.UnitTests/Compute/Kubernetes/ResourceInformerTests.cs
+++ b/server/ControlPlane.UnitTests/Compute/Kubernetes/ResourceInformerTests.cs
@@ -1,0 +1,558 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Threading.Channels;
+using System.Threading.RateLimiting;
+using k8s;
+using k8s.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Shouldly;
+using Tyger.ControlPlane.Compute.Kubernetes;
+using Xunit;
+
+namespace Tyger.ControlPlane.UnitTests.Compute.Kubernetes;
+
+public class ResourceInformerTests
+{
+    [Fact]
+    public async Task InitialList_EmitsToInitialChannelAndCompletes()
+    {
+        var fixture = new InformerFixture
+        {
+            NextList = Pods("rv-1", ("a", "1"), ("b", "1")),
+            NextWatchEvents = Array.Empty<(WatchEventType, V1Pod)>()
+        };
+
+        await fixture.RunUntilAsync(async () =>
+        {
+            var pods = new List<V1Pod>();
+            await foreach (var pod in fixture.InitialReader.ReadAllAsync())
+            {
+                pods.Add(pod);
+            }
+
+            pods.Select(p => p.Name()).ShouldBe(["a", "b"]);
+        });
+    }
+
+    [Fact]
+    public async Task WatchEvents_FlowToUpdatesChannel_AndBookmarkAdvancesResourceVersion()
+    {
+        var fixture = new InformerFixture
+        {
+            NextList = Pods("rv-1"),
+            NextWatchEvents = new[]
+            {
+                (WatchEventType.Added, Pod("a", "2")),
+                (WatchEventType.Modified, Pod("a", "3")),
+                (WatchEventType.Bookmark, Pod(name: null, "rv-bookmark")),
+                (WatchEventType.Deleted, Pod("a", "4")),
+            }
+        };
+
+        await fixture.RunUntilAsync(async () =>
+        {
+            await fixture.InitialReader.Completion;
+
+            var observed = new List<(WatchEventType, string?)>();
+            for (int i = 0; i < 3; i++)
+            {
+                var (t, pod) = await fixture.UpdatesReader.ReadAsync();
+                observed.Add((t, pod.Name()));
+            }
+
+            observed.ShouldBe(new[]
+            {
+                (WatchEventType.Added, (string?)"a"),
+                (WatchEventType.Modified, (string?)"a"),
+                (WatchEventType.Deleted, (string?)"a"),
+            });
+
+            // Wait for the next watch reconnect; it should use the bookmark's RV.
+            await fixture.WaitForWatchCountAsync(2);
+        });
+
+        // Initial watch used the list's RV; subsequent watches use the bookmark.
+        fixture.WatchResourceVersions[0].ShouldBe("rv-1");
+        fixture.WatchResourceVersions[1].ShouldBe("rv-bookmark");
+        // No re-list was needed.
+        fixture.ListCalls.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task KubernetesExceptionFromWatchEnumerator_ForcesReList()
+    {
+        var fixture = new InformerFixture
+        {
+            NextList = Pods("rv-1"),
+            NextWatchEvents = new Func<IAsyncEnumerable<(WatchEventType, V1Pod)>>(() =>
+                    ThrowingStream(new KubernetesException(new V1Status { Reason = "Expired" })))
+        };
+
+        await fixture.RunUntilAsync(async () =>
+        {
+            await fixture.InitialReader.Completion;
+
+            // Wait until we see a second list call (re-list after Expired).
+            await fixture.WaitForListCountAsync(2);
+        });
+
+        fixture.ListCalls[1].ResourceVersion.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task OnError_WithKubernetesException_ForcesReList()
+    {
+        var fixture = new InformerFixture
+        {
+            NextList = Pods("rv-1"),
+            NextWatchEvents = new Func<Action<Exception>, IAsyncEnumerable<(WatchEventType, V1Pod)>>(onError =>
+                    DeliverErrorAndComplete(onError, new KubernetesException(new V1Status { Reason = "Gone" })))
+        };
+
+        await fixture.RunUntilAsync(async () =>
+        {
+            await fixture.InitialReader.Completion;
+            await fixture.WaitForListCountAsync(2);
+        });
+
+        fixture.ListCalls[1].ResourceVersion.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task OnError_WithRepeatedDeserializeErrors_DropsConnectionWithoutReList()
+    {
+        var fixture = new InformerFixture
+        {
+            NextList = Pods("rv-1")
+        };
+
+        // 1st watch floods deserialize errors (circuit breaker should fire),
+        // 2nd watch immediately yields a real event so the test can observe
+        // that the reconnect happened without a re-list.
+        var watchCount = 0;
+        fixture.NextWatchEvents = new Func<Action<Exception>, IAsyncEnumerable<(WatchEventType, V1Pod)>>(onError =>
+        {
+            var current = Interlocked.Increment(ref watchCount);
+            return current == 1
+                ? FloodErrorsAndStallForever(onError, new JsonException("bad"), count: 20)
+                : SingleEventStream(WatchEventType.Added, Pod("a", "2"));
+        });
+
+        await fixture.RunUntilAsync(async () =>
+        {
+            await fixture.InitialReader.Completion;
+            // Wait for the post-flood reconnect to deliver its event.
+            var (t, _) = await fixture.UpdatesReader.ReadAsync();
+            t.ShouldBe(WatchEventType.Added);
+        });
+
+        // Crucially, the circuit breaker did NOT trigger a re-list.
+        fixture.ListCalls.Count.ShouldBe(1);
+        fixture.WatchCallCount.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task FiveConsecutiveEmptyWatches_ForceReList()
+    {
+        var fixture = new InformerFixture
+        {
+            NextList = Pods("rv-1"),
+            NextWatchEvents = Array.Empty<(WatchEventType, V1Pod)>() // every watch returns immediately with no events
+        };
+
+        await fixture.RunUntilAsync(async () =>
+        {
+            await fixture.InitialReader.Completion;
+            await fixture.WaitForListCountAsync(2);
+        });
+
+        // After 5 empty watches, the second list call should drop the rv.
+        fixture.ListCalls[1].ResourceVersion.ShouldBeNull();
+        fixture.WatchCallsBeforeListCount(2).ShouldBeGreaterThanOrEqualTo(5);
+    }
+
+    [Fact]
+    public async Task LongLivedEmptyWatches_DoNotForceReList()
+    {
+        var time = new FakeTimeProvider();
+        var fixture = new InformerFixture(time)
+        {
+            NextList = Pods("rv-1"),
+            NextWatchEvents = new Func<IAsyncEnumerable<(WatchEventType, V1Pod)>>(() => DelayThenComplete(time, TimeSpan.FromMinutes(1)))
+        };
+
+        await fixture.RunUntilAsync(async () =>
+        {
+            await fixture.InitialReader.Completion;
+            await fixture.WaitForWatchCountAsync(1);
+
+            for (int i = 0; i < 6; i++)
+            {
+                time.Advance(TimeSpan.FromMinutes(1));
+                await Task.Yield();
+                await fixture.WaitForWatchCountAsync(i + 2);
+            }
+
+            fixture.ListCalls.Count.ShouldBe(1);
+            fixture.WatchCallCount.ShouldBeGreaterThanOrEqualTo(7);
+        });
+    }
+
+    [Fact]
+    public async Task WatchRequestTimeout_ReconnectsWithoutReList()
+    {
+        var time = new FakeTimeProvider();
+        var fixture = new InformerFixture(time)
+        {
+            NextList = Pods("rv-1"),
+            NextWatchEvents = new Func<IAsyncEnumerable<(WatchEventType, V1Pod)>>(() => StallForeverStream(default))
+        };
+
+        await fixture.RunUntilAsync(async () =>
+        {
+            await fixture.InitialReader.Completion;
+            await fixture.WaitForWatchCountAsync(1);
+
+            time.Advance(TimeSpan.FromMinutes(6));
+            await Task.Yield();
+
+            await fixture.WaitForWatchCountAsync(2);
+
+            fixture.ListCalls.Count.ShouldBe(1);
+            fixture.WatchResourceVersions[1].ShouldBe("rv-1");
+        });
+    }
+
+    private static V1PodList Pods(string resourceVersion, params (string Name, string Rv)[] items)
+    {
+        return new V1PodList
+        {
+            Metadata = new V1ListMeta { ResourceVersion = resourceVersion },
+            Items = items.Select(i => Pod(i.Name, i.Rv)).ToList(),
+        };
+    }
+
+    private static V1Pod Pod(string? name, string resourceVersion)
+    {
+        return new V1Pod
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = name,
+                ResourceVersion = resourceVersion,
+            },
+        };
+    }
+
+    private static async IAsyncEnumerable<(WatchEventType, V1Pod)> ThrowingStream(Exception ex)
+    {
+        await Task.Yield();
+        throw ex;
+#pragma warning disable CS0162 // unreachable
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    private static async IAsyncEnumerable<(WatchEventType, V1Pod)> SingleEventStream(
+        WatchEventType type,
+        V1Pod pod,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.Yield();
+        yield return (type, pod);
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private static async IAsyncEnumerable<(WatchEventType, V1Pod)> StallForeverStream(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        try
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<(WatchEventType, V1Pod)> DelayThenComplete(
+        TimeProvider timeProvider,
+        TimeSpan delay,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        try
+        {
+            await Task.Delay(delay, timeProvider, ct);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<(WatchEventType, V1Pod)> DeliverErrorAndComplete(
+        Action<Exception> onError,
+        Exception error,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.Yield();
+        onError(error);
+        // The real k8s enumerator returns normally after invoking onError for
+        // a Status event (the server typically closes the stream right after).
+        // Honour cancellation requested by OnWatchError before yielding break.
+        try
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<(WatchEventType, V1Pod)> FloodErrorsAndStallForever(
+        Action<Exception> onError,
+        Exception error,
+        int count,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.Yield();
+        for (int i = 0; i < count && !ct.IsCancellationRequested; i++)
+        {
+            onError(error);
+        }
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        yield break;
+    }
+
+    private sealed class InformerFixture
+    {
+        private readonly Channel<V1Pod> _initial = Channel.CreateUnbounded<V1Pod>();
+        private readonly Channel<(WatchEventType, V1Pod)> _updates = Channel.CreateUnbounded<(WatchEventType, V1Pod)>();
+        private readonly TestableInformer _informer;
+        private readonly object _gate = new();
+
+        public InformerFixture(TimeProvider? time = null)
+        {
+            _informer = new TestableInformer(
+                Substitute.For<IKubernetes>(),
+                "default",
+                "label=val",
+                _initial.Writer,
+                _updates.Writer,
+                NullLogger.Instance,
+                this,
+                time ?? TimeProvider.System,
+                new NoopRateLimiter());
+        }
+
+        public ChannelReader<V1Pod> InitialReader => _initial.Reader;
+        public ChannelReader<(WatchEventType, V1Pod)> UpdatesReader => _updates.Reader;
+
+        public List<(string? ResourceVersion, string? Continue)> ListCalls { get; } = [];
+        public List<string?> WatchResourceVersions { get; } = [];
+        public int WatchCallCount { get; private set; }
+
+        public V1PodList NextList { get; set; } = new V1PodList { Metadata = new(), Items = [] };
+
+        // Either Func<IAsyncEnumerable<...>>, Func<Action<Exception>,IAsyncEnumerable<...>>, or IEnumerable<(WatchEventType,V1Pod)>.
+        public object NextWatchEvents { get; set; } = Array.Empty<(WatchEventType, V1Pod)>();
+
+        public int WatchCallsBeforeListCount(int listCount)
+        {
+            lock (_gate)
+            {
+                return _watchesByListIndex.Count >= listCount ? _watchesByListIndex[listCount - 1] : WatchCallCount;
+            }
+        }
+
+        public async Task WaitForListCountAsync(int target, TimeSpan? timeout = null)
+        {
+            timeout ??= TimeSpan.FromSeconds(5);
+            var deadline = DateTime.UtcNow + timeout.Value;
+            while (DateTime.UtcNow < deadline)
+            {
+                lock (_gate)
+                {
+                    if (ListCalls.Count >= target)
+                    {
+                        return;
+                    }
+                }
+
+                await Task.Delay(20);
+            }
+
+            throw new TimeoutException($"Timed out waiting for {target} list calls; saw {ListCalls.Count}.");
+        }
+
+        public async Task WaitForWatchCountAsync(int target, TimeSpan? timeout = null)
+        {
+            timeout ??= TimeSpan.FromSeconds(5);
+            var deadline = DateTime.UtcNow + timeout.Value;
+            while (DateTime.UtcNow < deadline)
+            {
+                lock (_gate)
+                {
+                    if (WatchCallCount >= target)
+                    {
+                        return;
+                    }
+                }
+
+                await Task.Delay(20);
+            }
+
+            throw new TimeoutException($"Timed out waiting for {target} watch calls; saw {WatchCallCount}.");
+        }
+
+        public async Task RunUntilAsync(Func<Task> assertion)
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            // Task.Run so the informer's hot loop doesn't monopolize xUnit's
+            // single-threaded synchronization context.
+            var task = Task.Run(() => _informer.ExecuteAsync(cts.Token));
+
+            try
+            {
+                await assertion();
+            }
+            finally
+            {
+                cts.Cancel();
+                await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(2)));
+                if (task.IsFaulted)
+                {
+                    await task; // surface unexpected informer failures
+                }
+            }
+        }
+
+        private readonly List<int> _watchesByListIndex = [];
+
+        internal Task<V1PodList> RecordList(string? resourceVersion, string? continueParameter)
+        {
+            lock (_gate)
+            {
+                ListCalls.Add((resourceVersion, continueParameter));
+                _watchesByListIndex.Add(WatchCallCount);
+            }
+
+            return Task.FromResult(NextList);
+        }
+
+        internal IAsyncEnumerable<(WatchEventType, V1Pod)> RecordWatch(string? resourceVersion, Action<Exception> onError)
+        {
+            lock (_gate)
+            {
+                WatchCallCount++;
+                WatchResourceVersions.Add(resourceVersion);
+            }
+
+            return NextWatchEvents switch
+            {
+                Func<IAsyncEnumerable<(WatchEventType, V1Pod)>> f => f(),
+                Func<Action<Exception>, IAsyncEnumerable<(WatchEventType, V1Pod)>> g => g(onError),
+                IEnumerable<(WatchEventType, V1Pod)> events => ToAsync(events),
+                _ => throw new InvalidOperationException("Unsupported NextWatchEvents value."),
+            };
+        }
+
+        private static async IAsyncEnumerable<(WatchEventType, V1Pod)> ToAsync(IEnumerable<(WatchEventType, V1Pod)> events)
+        {
+            foreach (var e in events)
+            {
+                yield return e;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestableInformer : ResourceInformer<V1Pod, V1PodList>
+    {
+        private readonly InformerFixture _fixture;
+
+        public TestableInformer(
+            IKubernetes client,
+            string @namespace,
+            string labelSelector,
+            ChannelWriter<V1Pod> initial,
+            ChannelWriter<(WatchEventType, V1Pod)> updates,
+            Microsoft.Extensions.Logging.ILogger logger,
+            InformerFixture fixture,
+            TimeProvider time,
+            RateLimiter limiter)
+            : base(client, @namespace, labelSelector, initial, updates, logger, time, limiter)
+        {
+            _fixture = fixture;
+        }
+
+        protected override Task<V1PodList> RetrieveResourceListAsync(
+            string namespaceParameter,
+            string? labelSelector,
+            string? resourceVersion,
+            string? continuationToken,
+            CancellationToken cancellationToken)
+        {
+            return _fixture.RecordList(resourceVersion, continuationToken);
+        }
+
+        protected override IAsyncEnumerable<(WatchEventType, V1Pod)> WatchResourceListAsync(
+            string namespaceParameter,
+            string? labelSelector,
+            string? resourceVersion,
+            string? continuationToken,
+            Action<Exception> onError,
+            CancellationToken cancellationToken)
+        {
+            return _fixture.RecordWatch(resourceVersion, onError);
+        }
+    }
+
+    private sealed class NoopRateLimiter : RateLimiter
+    {
+        public override TimeSpan? IdleDuration => null;
+
+        public override RateLimiterStatistics? GetStatistics() => null;
+
+        protected override RateLimitLease AttemptAcquireCore(int permitCount) => new NoopLease();
+
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
+            => ValueTask.FromResult<RateLimitLease>(new NoopLease());
+
+        private sealed class NoopLease : RateLimitLease
+        {
+            public override bool IsAcquired => true;
+            public override IEnumerable<string> MetadataNames => [];
+            public override bool TryGetMetadata(string metadataName, out object? metadata)
+            {
+                metadata = null;
+                return false;
+            }
+        }
+    }
+}

--- a/server/ControlPlane.UnitTests/Tyger.ControlPlane.UnitTests.csproj
+++ b/server/ControlPlane.UnitTests/Tyger.ControlPlane.UnitTests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/server/ControlPlane.UnitTests/packages.lock.json
+++ b/server/ControlPlane.UnitTests/packages.lock.json
@@ -8,6 +8,12 @@
         "resolved": "8.0.0",
         "contentHash": "EMkj/2F6n6IVPrvGYkqzGJs6phuGGkq6N+E7KW9rNyzNxXbwQ1KfMqWyXNf9nCNEQOA6IjFwmOLvkriwKE7Orw=="
       },
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[9.10.0, )",
+        "resolved": "9.10.0",
+        "contentHash": "hpRMeUOqEz+I5HKu8WXnYr2HYqu2neBX+bgAwQqVLj/UnQxys8JhC6ep4Sp+rPj0mRDxSOiCFASMLxACu0jeRQ=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.3.0, )",

--- a/server/ControlPlane/Compute/Kubernetes/LoggerExtensions.cs
+++ b/server/ControlPlane/Compute/Kubernetes/LoggerExtensions.cs
@@ -26,6 +26,12 @@ public static partial class LoggerExtensions
     [LoggerMessage(LogLevel.Error, "Error while watching resources.")]
     public static partial void ErrorWatchingResources(this ILogger logger, Exception exception);
 
+    [LoggerMessage(LogLevel.Warning, "Watch request exceeded {lifetimeSeconds:F0}s without closing; reconnecting.")]
+    public static partial void ResourceInformerWatchRequestExceededLifetime(this ILogger logger, double lifetimeSeconds);
+
+    [LoggerMessage(LogLevel.Warning, "Watch connection returned without events {count} times in a row; forcing a full re-list to recover.")]
+    public static partial void ResourceInformerEmptyWatches(this ILogger logger, int count);
+
     [LoggerMessage(LogLevel.Error, "Error listening for changes to run records.")]
     public static partial void ErrorListeningForRunCanges(this ILogger logger, Exception exception);
 

--- a/server/ControlPlane/Compute/Kubernetes/ResourceInformer.cs
+++ b/server/ControlPlane/Compute/Kubernetes/ResourceInformer.cs
@@ -10,7 +10,7 @@ namespace Tyger.ControlPlane.Compute.Kubernetes;
 
 // Inspired by https://github.com/microsoft/reverse-proxy/blob/c9042d21927716f32e072fae4b634943de9e18cc/src/Kubernetes.Controller/Client/ResourceInformer.cs
 
-public abstract class ResourceInformer<TResource, TListResource>
+public abstract class ResourceInformer<TResource, TListResource> : IDisposable
     where TResource : class, IKubernetesObject<V1ObjectMeta>, new()
     where TListResource : class, IKubernetesObject<V1ListMeta>, IItems<TResource>, new()
 {
@@ -20,12 +20,12 @@ public abstract class ResourceInformer<TResource, TListResource>
 
     // If the server does not close within a short grace period after the
     // requested timeout, assume the stream is stuck and reconnect locally.
-    private static readonly TimeSpan WatchRequestTimeoutGracePeriod = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan s_watchRequestTimeoutGracePeriod = TimeSpan.FromSeconds(30);
 
     // An empty watch that lived for at least this long is treated as a normal
     // reconnect (for example server timeout / infra idle close), not as a
     // tight-loop failure.
-    private static readonly TimeSpan HealthyEmptyWatchDuration = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan s_healthyEmptyWatchDuration = TimeSpan.FromSeconds(30);
 
     // If WatchAsync returns this many times in a row without yielding any
     // events, force a full re-list. This defends against silent failure modes
@@ -48,6 +48,7 @@ public abstract class ResourceInformer<TResource, TListResource>
     private readonly ILogger _logger;
     private readonly TimeProvider _timeProvider;
     private readonly RateLimiter _reconnectLimiter;
+    private readonly bool _ownsReconnectLimiter;
 
     private enum WatchCompletion
     {
@@ -73,6 +74,7 @@ public abstract class ResourceInformer<TResource, TListResource>
         _updatesChannel = updatesChannel;
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _ownsReconnectLimiter = reconnectLimiter is null;
         _reconnectLimiter = reconnectLimiter ?? new TokenBucketRateLimiter(new()
         {
             ReplenishmentPeriod = TimeSpan.FromSeconds(5),
@@ -83,6 +85,16 @@ public abstract class ResourceInformer<TResource, TListResource>
     }
 
     protected IKubernetes Client { get; init; }
+
+    public void Dispose()
+    {
+        if (_ownsReconnectLimiter)
+        {
+            _reconnectLimiter.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
+    }
 
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
@@ -269,12 +281,12 @@ public abstract class ResourceInformer<TResource, TListResource>
             {
                 if (Interlocked.Exchange(ref requestLifetimeExceeded, 1) == 0)
                 {
-                    _logger.ResourceInformerWatchRequestExceededLifetime((WatchRequestTimeout + WatchRequestTimeoutGracePeriod).TotalSeconds);
+                    _logger.ResourceInformerWatchRequestExceededLifetime((WatchRequestTimeout + s_watchRequestTimeoutGracePeriod).TotalSeconds);
                     TryCancel(cts);
                 }
             },
             state: null,
-            dueTime: WatchRequestTimeout + WatchRequestTimeoutGracePeriod,
+            dueTime: WatchRequestTimeout + s_watchRequestTimeoutGracePeriod,
             period: Timeout.InfiniteTimeSpan);
 
         // The k8s client invokes this callback for two distinct kinds of
@@ -339,9 +351,10 @@ public abstract class ResourceInformer<TResource, TListResource>
             // reconnect.
         }
 
-        if (streamEndedError != null)
+        var terminalStreamError = Volatile.Read(ref streamEndedError);
+        if (terminalStreamError != null)
         {
-            throw streamEndedError;
+            throw terminalStreamError;
         }
 
         if (sawEvents)
@@ -350,7 +363,7 @@ public abstract class ResourceInformer<TResource, TListResource>
         }
 
         var watchDuration = _timeProvider.GetUtcNow() - watchStartedAt;
-        if (Volatile.Read(ref requestLifetimeExceeded) != 0 || watchDuration >= HealthyEmptyWatchDuration)
+        if (Volatile.Read(ref requestLifetimeExceeded) != 0 || watchDuration >= s_healthyEmptyWatchDuration)
         {
             return WatchCompletion.HealthyNoEventClosure;
         }

--- a/server/ControlPlane/Compute/Kubernetes/ResourceInformer.cs
+++ b/server/ControlPlane/Compute/Kubernetes/ResourceInformer.cs
@@ -178,7 +178,11 @@ public abstract class ResourceInformer<TResource, TListResource> : IDisposable
                 }
 
                 // rate limiting the reconnect loop
-                await _reconnectLimiter.AcquireAsync(cancellationToken: cancellationToken);
+                using var lease = await _reconnectLimiter.AcquireAsync(cancellationToken: cancellationToken);
+                if (!lease.IsAcquired)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), _timeProvider, cancellationToken);
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -314,7 +318,7 @@ public abstract class ResourceInformer<TResource, TListResource> : IDisposable
         {
             if (error is KubernetesException kubernetesError)
             {
-                streamEndedError = kubernetesError;
+                Volatile.Write(ref streamEndedError, kubernetesError);
                 TryCancel(cts);
                 return;
             }

--- a/server/ControlPlane/Compute/Kubernetes/ResourceInformer.cs
+++ b/server/ControlPlane/Compute/Kubernetes/ResourceInformer.cs
@@ -343,6 +343,7 @@ public abstract class ResourceInformer<TResource, TListResource> : IDisposable
             await foreach (var (watchEventType, item) in watchStream.WithCancellation(cts.Token))
             {
                 sawEvents = true;
+                Interlocked.Exchange(ref deserializeErrorCount, 0);
                 await OnEvent(watchEventType, item);
             }
         }

--- a/server/ControlPlane/Compute/Kubernetes/ResourceInformer.cs
+++ b/server/ControlPlane/Compute/Kubernetes/ResourceInformer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Net.Sockets;
 using System.Threading.Channels;
 using System.Threading.RateLimiting;
 using k8s;
@@ -15,6 +14,31 @@ public abstract class ResourceInformer<TResource, TListResource>
     where TResource : class, IKubernetesObject<V1ObjectMeta>, new()
     where TListResource : class, IKubernetesObject<V1ListMeta>, IItems<TResource>, new()
 {
+    // Bound each watch request so the apiserver periodically closes even a
+    // completely idle but healthy stream and we get a chance to reconnect.
+    protected static readonly TimeSpan WatchRequestTimeout = TimeSpan.FromMinutes(5);
+
+    // If the server does not close within a short grace period after the
+    // requested timeout, assume the stream is stuck and reconnect locally.
+    private static readonly TimeSpan WatchRequestTimeoutGracePeriod = TimeSpan.FromSeconds(30);
+
+    // An empty watch that lived for at least this long is treated as a normal
+    // reconnect (for example server timeout / infra idle close), not as a
+    // tight-loop failure.
+    private static readonly TimeSpan HealthyEmptyWatchDuration = TimeSpan.FromSeconds(30);
+
+    // If WatchAsync returns this many times in a row without yielding any
+    // events, force a full re-list. This defends against silent failure modes
+    // where the server immediately closes the stream (e.g. an in-band Status
+    // event the enumerator absorbs) and the reconnect loop would otherwise
+    // spin forever observing nothing.
+    private const int EmptyWatchReListThreshold = 5;
+
+    // A single bad watch frame is harmless and just gets logged. If we see
+    // this many in a row within one watch, drop and reconnect rather than
+    // sit logging the same parse failure forever.
+    private const int MaxWatchDeserializeErrors = 10;
+
     private Dictionary<string, TResource> _cache = [];
     private string? _lastResourceVersion;
     private readonly string? _labelSelector;
@@ -22,6 +46,15 @@ public abstract class ResourceInformer<TResource, TListResource>
     private readonly ChannelWriter<(WatchEventType eventType, TResource resource)> _updatesChannel;
     private readonly string _namespace;
     private readonly ILogger _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly RateLimiter _reconnectLimiter;
+
+    private enum WatchCompletion
+    {
+        ObservedEvents,
+        HealthyNoEventClosure,
+        SuspiciousEmptyClosure,
+    }
 
     protected ResourceInformer(
         IKubernetes client,
@@ -29,7 +62,9 @@ public abstract class ResourceInformer<TResource, TListResource>
         string labelSelector,
         ChannelWriter<TResource> initialResourcesChannel,
         ChannelWriter<(WatchEventType eventType, TResource resource)> updatesChannel,
-        ILogger logger)
+        ILogger logger,
+        TimeProvider? timeProvider = null,
+        RateLimiter? reconnectLimiter = null)
     {
         Client = client;
         _namespace = @namespace;
@@ -37,15 +72,24 @@ public abstract class ResourceInformer<TResource, TListResource>
         _initialResourcesChannel = initialResourcesChannel;
         _updatesChannel = updatesChannel;
         _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _reconnectLimiter = reconnectLimiter ?? new TokenBucketRateLimiter(new()
+        {
+            ReplenishmentPeriod = TimeSpan.FromSeconds(5),
+            TokensPerPeriod = 1,
+            QueueLimit = 1000,
+            TokenLimit = 3,
+        });
     }
 
     protected IKubernetes Client { get; init; }
 
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        var limiter = new TokenBucketRateLimiter(new() { ReplenishmentPeriod = TimeSpan.FromSeconds(5), TokensPerPeriod = 1, QueueLimit = 1000, TokenLimit = 3 });
         var shouldSync = true;
         var firstSync = true;
+        var consecutiveEmptyWatches = 0;
+
         while (true)
         {
             try
@@ -58,6 +102,7 @@ public abstract class ResourceInformer<TResource, TListResource>
                     {
                         await ListAsync(firstSync, cancellationToken);
                         shouldSync = false;
+                        consecutiveEmptyWatches = 0;
                     }
 
                     if (firstSync)
@@ -66,30 +111,62 @@ public abstract class ResourceInformer<TResource, TListResource>
                         firstSync = false;
                     }
 
-                    await WatchAsync(cancellationToken);
+                    switch (await WatchAsync(cancellationToken))
+                    {
+                        case WatchCompletion.ObservedEvents:
+                        case WatchCompletion.HealthyNoEventClosure:
+                            consecutiveEmptyWatches = 0;
+                            break;
+                        case WatchCompletion.SuspiciousEmptyClosure:
+                            if (++consecutiveEmptyWatches >= EmptyWatchReListThreshold)
+                            {
+                                _logger.ResourceInformerEmptyWatches(consecutiveEmptyWatches);
+                                _lastResourceVersion = null;
+                                shouldSync = true;
+                                consecutiveEmptyWatches = 0;
+                            }
+
+                            break;
+                    }
                 }
-                catch (IOException ex) when (ex.InnerException is SocketException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    _logger.ErrorWatchingResources(ex);
+                    throw;
                 }
                 catch (KubernetesException ex)
                 {
                     _logger.ErrorWatchingResources(ex);
 
-                    // deal with this non-recoverable condition "too old resource version"
-                    // with a re-sync to listing everything again ensuring no subscribers miss updates
-                    if (ex is KubernetesException kubernetesError)
-                    {
-                        if (string.Equals(kubernetesError.Status.Reason, "Expired", StringComparison.Ordinal))
-                        {
-                            _lastResourceVersion = null;
-                            shouldSync = true;
-                        }
-                    }
+                    // Any in-band Status from the apiserver means the watch
+                    // is over and we cannot trust _lastResourceVersion to
+                    // still be valid (Reason == "Expired" is the canonical
+                    // case, but Gone, Forbidden, etc. are equally
+                    // unrecoverable from a watch standpoint). Re-list so no
+                    // subscribers miss updates.
+                    _lastResourceVersion = null;
+                    shouldSync = true;
+                }
+                catch (Exception ex)
+                {
+                    // Any other failure (IOException, HttpRequestException,
+                    // HttpIOException, HttpOperationException for non-2xx
+                    // start-of-watch responses, ObjectDisposedException on a
+                    // torn-down HttpClient, etc.) is treated as a transient
+                    // transport problem: log, fall through to the rate
+                    // limiter, and reconnect using the same
+                    // _lastResourceVersion. If the version is actually stale,
+                    // the next watch attempt will return a KubernetesException
+                    // (handled above) and trigger a re-list.
+                    //
+                    // Catching Exception here is deliberate: it prevents
+                    // unexpected failure modes from bypassing the rate
+                    // limiter and burning CPU in a tight reconnect loop, and
+                    // ensures the BackgroundService never terminates.
+                    _logger.ErrorWatchingResources(ex);
                 }
 
                 // rate limiting the reconnect loop
-                await limiter.AcquireAsync(cancellationToken: cancellationToken);
+                await _reconnectLimiter.AcquireAsync(cancellationToken: cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -97,7 +174,20 @@ public abstract class ResourceInformer<TResource, TListResource>
             }
             catch (Exception error)
             {
+                // Last-resort safety net: nothing in the inner block should
+                // reach here (everything above is either handled or
+                // rethrown for cancellation). If something does, log and
+                // back off so we cannot spin even if the rate limiter
+                // itself is the thing failing.
                 _logger.ErrorWatchingResources(error);
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), _timeProvider, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
             }
         }
     }
@@ -114,6 +204,7 @@ public abstract class ResourceInformer<TResource, TListResource>
         string? labelSelector,
         string? resourceVersion,
         string? continuationToken,
+        Action<Exception> onError,
         CancellationToken cancellationToken);
 
     private async Task ListAsync(bool firstSync, CancellationToken cancellationToken)
@@ -168,41 +259,113 @@ public abstract class ResourceInformer<TResource, TListResource>
         while (!string.IsNullOrEmpty(continueParameter));
     }
 
-    private async Task WatchAsync(CancellationToken cancellationToken)
+    private async Task<WatchCompletion> WatchAsync(CancellationToken cancellationToken)
     {
-        // completion source helps turn OnClose callback into something awaitable
-        var watcherCompletionSource = new TaskCompletionSource<int>();
-
-        var lastEventUtc = DateTime.UtcNow;
-
-        var cts = new CancellationTokenSource();
-        var combinedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
-
-        // force Reconnect if no events have arrived after a certain time
-        using var checkLastEventUtcTimer = new Timer(
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var watchStartedAt = _timeProvider.GetUtcNow();
+        var requestLifetimeExceeded = 0;
+        using var watchLifetimeTimer = _timeProvider.CreateTimer(
             _ =>
             {
-                var lastEvent = DateTime.UtcNow - lastEventUtc;
-                if (lastEvent > TimeSpan.FromMinutes(9.5))
+                if (Interlocked.Exchange(ref requestLifetimeExceeded, 1) == 0)
                 {
-                    lastEventUtc = DateTime.MaxValue;
-                    cts.Cancel();
+                    _logger.ResourceInformerWatchRequestExceededLifetime((WatchRequestTimeout + WatchRequestTimeoutGracePeriod).TotalSeconds);
+                    TryCancel(cts);
                 }
             },
             state: null,
-            dueTime: TimeSpan.FromSeconds(45),
-            period: TimeSpan.FromSeconds(45));
+            dueTime: WatchRequestTimeout + WatchRequestTimeoutGracePeriod,
+            period: Timeout.InfiniteTimeSpan);
+
+        // The k8s client invokes this callback for two distinct kinds of
+        // problems, neither of which throws out of the async enumerator:
+        //   1. Server-side errors delivered as in-band "Status" events
+        //      (e.g. Reason == "Expired" for too-old resourceVersion, or
+        //      any other Status the apiserver writes before closing the
+        //      stream). These mean the watch is over; we must surface
+        //      them so the outer loop can reconnect, and re-list when
+        //      the resourceVersion is no longer valid.
+        //   2. Per-line deserialization errors (JsonException, etc.). A
+        //      single bad line is harmless - the next ReadLineAsync may
+        //      well succeed - so we just log and keep enumerating. As a
+        //      circuit breaker, if they keep arriving we eventually drop
+        //      the connection and reconnect.
+        //
+        // Transport-level failures (IOException, HttpRequestException,
+        // socket resets, TLS errors, ObjectDisposedException, ...) do
+        // NOT come through this callback; they are thrown out of the
+        // underlying ReadLineAsync and propagate out of the await
+        // foreach below, where the outer ExecuteAsync handles them.
+        KubernetesException? streamEndedError = null;
+        var deserializeErrorCount = 0;
+        void OnWatchError(Exception error)
+        {
+            if (error is KubernetesException kubernetesError)
+            {
+                streamEndedError = kubernetesError;
+                TryCancel(cts);
+                return;
+            }
+
+            _logger.ErrorWatchingResources(error);
+
+            if (Interlocked.Increment(ref deserializeErrorCount) >= MaxWatchDeserializeErrors)
+            {
+                // Not fatal in itself, but we shouldn't sit in a loop
+                // logging the same parse failure forever. Drop the
+                // connection and let the outer loop reconnect.
+                TryCancel(cts);
+            }
+        }
 
         // begin watching where list left off
-        var watchStream = WatchResourceListAsync(_namespace, _labelSelector, _lastResourceVersion, null, combinedTokenSource.Token);
+        var watchStream = WatchResourceListAsync(_namespace, _labelSelector, _lastResourceVersion, null, OnWatchError, cts.Token);
 
-        await foreach (var (watchEventType, item) in watchStream)
+        var sawEvents = false;
+        try
         {
-            if (!watcherCompletionSource.Task.IsCompleted)
+            await foreach (var (watchEventType, item) in watchStream.WithCancellation(cts.Token))
             {
-                lastEventUtc = DateTime.UtcNow;
+                sawEvents = true;
                 await OnEvent(watchEventType, item);
             }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Cancelled either by the in-band Status handler above or by the
+            // deserialize-error circuit breaker. In both cases we want to
+            // fall through so the outer loop can react: rethrow the Status as
+            // a KubernetesException below (forcing a re-list), or simply
+            // reconnect.
+        }
+
+        if (streamEndedError != null)
+        {
+            throw streamEndedError;
+        }
+
+        if (sawEvents)
+        {
+            return WatchCompletion.ObservedEvents;
+        }
+
+        var watchDuration = _timeProvider.GetUtcNow() - watchStartedAt;
+        if (Volatile.Read(ref requestLifetimeExceeded) != 0 || watchDuration >= HealthyEmptyWatchDuration)
+        {
+            return WatchCompletion.HealthyNoEventClosure;
+        }
+
+        return WatchCompletion.SuspiciousEmptyClosure;
+    }
+
+    private static void TryCancel(CancellationTokenSource cancellationTokenSource)
+    {
+        try
+        {
+            cancellationTokenSource.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
         }
     }
 
@@ -255,14 +418,16 @@ public class PodInformer : ResourceInformer<V1Pod, V1PodList>
             cancellationToken: cancellationToken);
     }
 
-    protected override IAsyncEnumerable<(WatchEventType, V1Pod)> WatchResourceListAsync(string namespaceParameter, string? labelSelector, string? resourceVersion, string? continuationToken, CancellationToken cancellationToken)
+    protected override IAsyncEnumerable<(WatchEventType, V1Pod)> WatchResourceListAsync(string namespaceParameter, string? labelSelector, string? resourceVersion, string? continuationToken, Action<Exception> onError, CancellationToken cancellationToken)
     {
         return Client.CoreV1.WatchListNamespacedPodAsync(
             namespaceParameter,
             labelSelector: labelSelector,
             resourceVersion: resourceVersion,
             continueParameter: continuationToken,
+            timeoutSeconds: (int)WatchRequestTimeout.TotalSeconds,
             allowWatchBookmarks: true,
+            onError: onError,
             cancellationToken: cancellationToken);
     }
 }

--- a/server/ControlPlane/Compute/Kubernetes/RunStateObserver.cs
+++ b/server/ControlPlane/Compute/Kubernetes/RunStateObserver.cs
@@ -28,6 +28,7 @@ public class RunStateObserver : BackgroundService
     private readonly Dictionary<long, List<ChannelWriter<(RunObjects, WatchEventType, V1Pod)>>> _listeners = [];
     private readonly List<Channel<(WatchEventType, V1Pod)>> _partitionedPodUpdateChannels = [.. Enumerable.Range(0, PartitionCount).Select(_ => Channel.CreateBounded<(WatchEventType, V1Pod)>(ParitionChannelSize))];
     private Task? _podInformerTask;
+    private PodInformer? _podInformer;
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly Channel<(WatchEventType eventType, V1Pod resource)> _podUpdatesChannel = Channel.CreateBounded<(WatchEventType, V1Pod)>(PartitionCount * ParitionChannelSize);
     private readonly Channel<(bool leaseHeld, int token)> _onLeaseOwnershipAcquiredChannel = Channel.CreateUnbounded<(bool, int)>();
@@ -51,6 +52,7 @@ public class RunStateObserver : BackgroundService
         var initialPodChannel = Channel.CreateBounded<V1Pod>(new BoundedChannelOptions(1024));
 
         var podInformer = new PodInformer(_kubernetesClient, _kubernetesOptions.Namespace, RunLabel, initialPodChannel.Writer, _podUpdatesChannel.Writer, _loggingFactory.CreateLogger<PodInformer>());
+        _podInformer = podInformer;
 
         _podInformerTask = podInformer.ExecuteAsync(_cancellationTokenSource.Token);
 
@@ -307,5 +309,12 @@ public class RunStateObserver : BackgroundService
         }
 
         return null;
+    }
+
+    public override void Dispose()
+    {
+        _podInformer?.Dispose();
+        base.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/server/ControlPlane/Compute/Kubernetes/RunStateObserver.cs
+++ b/server/ControlPlane/Compute/Kubernetes/RunStateObserver.cs
@@ -313,8 +313,10 @@ public class RunStateObserver : BackgroundService
 
     public override void Dispose()
     {
-        _podInformer?.Dispose();
         base.Dispose();
+        _cancellationTokenSource.Cancel();
+        _podInformer?.Dispose();
+        _cancellationTokenSource.Dispose();
         GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
## Summary

Fix a regression in `ResourceInformer` where the watch loop silently stops observing pod state changes, and harden the reconnect/recovery logic against several additional failure modes. This regression occurred in #297 and would result in the status of runs not updating until the server restarts.

## The regression

When the watch API was migrated from the callback-based `Watcher<T>` to the `IAsyncEnumerable` API (`WatchListNamespacedPodAsync`), the `onError` callback parameter was dropped from the call. The upstream k8s client uses this callback to deliver two classes of errors that do **not** throw out of the async enumerator:

1. **In-band Status events** (e.g. `Reason: "Expired"` for a stale `resourceVersion`) — these mean the watch is over and the resource version is no longer valid.
2. **Per-line deserialization errors** (`JsonException`, etc.) — the enumerator logs them and continues to the next line.

Without the `onError` plumbing, in-band `KubernetesException` errors were silently swallowed. The watch stream would end, the loop would reconnect using the same stale `resourceVersion`, the server would immediately send another Status error, and the cycle would repeat — spinning forever without ever re-listing or delivering updates to subscribers.

## What this PR does

**Core fix:**
- Plumb `onError` through `WatchResourceListAsync` to the k8s client call.
- `OnWatchError` classifies errors: `KubernetesException` triggers cancellation of the current watch and is rethrown, forcing a full re-list in `ExecuteAsync`. Deserialization errors are logged and counted; a circuit breaker drops the connection after 10 consecutive failures.

**Watch lifecycle hardening:**
- Pass `timeoutSeconds` to the apiserver so it periodically closes even idle-but-healthy streams, giving the informer a regular reconnect cadence (~5 min).
- Add a local lifetime timer (`WatchRequestTimeout + 30s` grace) as a safety net if the server doesn't honor its own timeout.
- Track empty-watch durations: only watches that close quickly without events ("suspicious") count toward the `EmptyWatchReListThreshold` (5). Long-lived empty closures (server timeout, infra idle close) are treated as healthy and don't tick the counter.

**Error handling in `ExecuteAsync`:**
- Properly tiered catch chain: `OperationCanceledException` (rethrow on user cancellation) → `KubernetesException` (clear RV, force re-list) → `Exception` (log, reconnect with same RV — the next attempt's Status response will force a re-list if needed).
- Outermost safety net with a 5-second backoff so an unexpected failure (e.g. rate limiter itself throwing) cannot spin.
- Removed the narrow `IOException` / `SocketException` catch that missed many real transport failures.