### PR TITLE
Speed up release pipeline

### DIFF
--- a/.github/workflows/delete-pr-environments.yml
+++ b/.github/workflows/delete-pr-environments.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Log in to Azure
         uses: ./.github/actions/login-azure
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -3,7 +3,6 @@ name: Tyger
 on:
   push:
     branches: [main]
-    tags: ["v*.*.*"]
   pull_request: # all branches
   workflow_dispatch:
 
@@ -64,12 +63,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v5
         with:
           global-json-file: server/global.json
 
@@ -351,7 +350,7 @@ jobs:
         run: |
           make login-acr
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
@@ -382,7 +381,7 @@ jobs:
       - name: Log in to Azure
         uses: ./.github/actions/login-azure
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
@@ -425,7 +424,7 @@ jobs:
       - name: Log in to Azure
         uses: ./.github/actions/login-azure
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
@@ -465,7 +464,7 @@ jobs:
         run: |
           make login-acr
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
@@ -509,7 +508,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
@@ -660,12 +659,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v5
         with:
           global-json-file: server/global.json
 
@@ -696,13 +695,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         if: matrix.language == 'go'
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v5
         if: matrix.language == 'csharp'
         with:
           global-json-file: server/global.json
@@ -771,50 +770,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-
-  release:
-    if: startsWith(github.ref, 'refs/tags/')
-    needs:
-      - unit-tests-and-format
-      - integration-tests
-      - get-config
-      - verify-docker
-      - windows-smoke-tests
-    environment:
-      name: publish-container-images
-    env:
-      DEVELOPER_CONFIG_BASE64: ${{ needs.get-config.outputs.DEVELOPER_CONFIG_BASE64 }}
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: cli/go.mod
-          cache-dependency-path: cli/go.sum
-
-      - name: get container registry
-        run: |
-          set -euo pipefail
-          official_pull_container_registry=$(echo "$DEVELOPER_CONFIG_BASE64" | base64 -d | jq -r '.officialPullContainerRegistry.fqdn')
-          echo "GORELEASER_CONTAINER_REGISTRY=$(echo $official_pull_container_registry)" >> $GITHUB_ENV
-          official_pull_container_registry_directory=$(echo "$DEVELOPER_CONFIG_BASE64" | base64 -d | jq -r '.officialPullContainerRegistry.directory // ""')
-          echo "GORELEASER_CONTAINER_REGISTRY_DIRECTORY=$(echo $official_pull_container_registry_directory)" >> $GITHUB_ENV
-
-      - name: test image published
-        run: |
-          set -euo pipefail
-          docker pull "${GORELEASER_CONTAINER_REGISTRY}${GORELEASER_CONTAINER_REGISTRY_DIRECTORY}/tyger-server:$(git describe --tags)"
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          version: v1.21.2
-          workdir: cli
-          args: release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Get container registry
+        run: |
+          set -euo pipefail
+          developer_config_json=$(scripts/get-config.sh --dev -o json | jq -c)
+          official_pull_container_registry=$(jq -r '.officialPullContainerRegistry.fqdn' <<<"$developer_config_json")
+          echo "GORELEASER_CONTAINER_REGISTRY=$official_pull_container_registry" >> "$GITHUB_ENV"
+          official_pull_container_registry_directory=$(jq -r '.officialPullContainerRegistry.directory // ""' <<<"$developer_config_json")
+          echo "GORELEASER_CONTAINER_REGISTRY_DIRECTORY=$official_pull_container_registry_directory" >> "$GITHUB_ENV"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: v1.21.2
+          workdir: cli
+          args: release --clean
+
+      - name: Verify official artifacts published
+        timeout-minutes: 35
+        run: |
+          set -euo pipefail
+
+          mapfile -t artifact_refs < <(EXPLICIT_IMAGE_TAG="$GITHUB_REF_NAME" make -s list-official-artifacts)
+          if (( ${#artifact_refs[@]} == 0 )); then
+            echo "ERROR: no official artifact references were generated."
+            exit 1
+          fi
+
+          max_attempts=31
+          retry_delay_seconds=60
+
+          for attempt in $(seq 1 "$max_attempts"); do
+            missing_artifacts=()
+
+            echo "Checking official artifact manifests (attempt ${attempt}/${max_attempts})..."
+
+            for artifact_ref in "${artifact_refs[@]}"; do
+              echo "Checking $artifact_ref"
+              if docker manifest inspect "$artifact_ref" >/dev/null 2>&1; then
+                echo "Found $artifact_ref"
+              else
+                echo "Missing $artifact_ref"
+                missing_artifacts+=("$artifact_ref")
+              fi
+            done
+
+            if (( ${#missing_artifacts[@]} == 0 )); then
+              echo "All official image and Helm chart manifests are available."
+              exit 0
+            fi
+
+            if (( attempt == max_attempts )); then
+              echo "ERROR: official artifacts were not available after 30 minutes."
+              exit 1
+            fi
+
+            echo "Official artifacts not ready. Attempt ${attempt}/${max_attempts}. ${#missing_artifacts[@]} missing artifact manifest(s). Retrying in 60 seconds."
+            sleep "$retry_delay_seconds"
+          done

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,12 @@ _docker-build:
 	container_registry_spec='${CONTAINER_REGISTRY_SPEC}'
 	registry=$$(echo "$${container_registry_spec}" | jq -r '.fqdn')
 	directory=$$(echo "$${container_registry_spec}" | jq -r '.directory // ""')
+	only_list_artifacts_arg=""
+	if [[ "${DOCKER_BUILD_ONLY_LIST_ARTIFACTS}" == "true" ]]; then
+		only_list_artifacts_arg="--only-list-artifacts"
+	fi
 
-	scripts/build-images.sh $$target_arg ${DOCKER_BUILD_ARCH_FLAGS} ${DOCKER_BUILD_PUSH_FLAGS} --tag "$$tag" --registry "$${registry}" --registry-directory "$${directory}"
+	scripts/build-images.sh $$target_arg ${DOCKER_BUILD_ARCH_FLAGS} ${DOCKER_BUILD_PUSH_FLAGS} $${only_list_artifacts_arg} --tag "$$tag" --registry "$${registry}" --registry-directory "$${directory}"
 
 docker-build-test: login-acr
 	$(MAKE) _docker-build DOCKER_BUILD_TARGET=test
@@ -99,7 +103,12 @@ docker-build: docker-build-test docker-build-server docker-build-client
 publish-official-images:
 	container_registry_spec=$$(echo '${DEVELOPER_CONFIG_JSON}' | jq -c '.officialPushContainerRegistry')
 	export EXPLICIT_IMAGE_TAG="$$(git describe --tags)"
-	$(MAKE) DOCKER_BUILD_ARCH_FLAGS="--arch amd64 --arch arm64" CONTAINER_REGISTRY_SPEC="$${container_registry_spec}" docker-build-server docker-build-client docker-build-helm
+	$(MAKE) DOCKER_BUILD_ARCH_FLAGS="--arch amd64 --arch arm64" DOCKER_BUILD_PUSH_FLAGS="--push --push-force" CONTAINER_REGISTRY_SPEC="$${container_registry_spec}" docker-build-server docker-build-client docker-build-helm
+
+list-official-artifacts:
+	container_registry_spec=$$(echo '${DEVELOPER_CONFIG_JSON}' | jq -c '.officialPullContainerRegistry')
+	export EXPLICIT_IMAGE_TAG="$${EXPLICIT_IMAGE_TAG:-$$(git describe --tags)}"
+	$(MAKE) DOCKER_BUILD_ONLY_LIST_ARTIFACTS="true" DOCKER_BUILD_ARCH_FLAGS="--arch amd64 --arch arm64" DOCKER_BUILD_PUSH_FLAGS="" CONTAINER_REGISTRY_SPEC="$${container_registry_spec}" docker-build-server docker-build-client docker-build-helm
 
 publish-ghcr:
 	container_registry_spec="{\"fqdn\": \"ghcr.io\", \"directory\": \"/$${GITHUB_REPOSITORY}\"}"

--- a/Makefile.cloud
+++ b/Makefile.cloud
@@ -64,6 +64,10 @@ set-context:
 	done
 
 login-acr:
+	if [[ "${DOCKER_BUILD_ONLY_LIST_ARTIFACTS}" == "true" ]]; then
+		exit 0
+	fi
+
 	registry=$$(echo '${CONTAINER_REGISTRY_SPEC}' | jq -r '.fqdn')
 	if [[ "$${registry}" =~ \.azurecr\.io$$ ]]; then
 		if ! ./scripts/check-docker-login.sh "$${registry}"; then

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -48,11 +48,7 @@ archives:
         format: zip
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  use: github-native
 
 release:
   draft: true

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -22,6 +22,7 @@ Options:
   --arch amd64|arm64               The architecture to build for. Can be specified multiple times.
   --push                           Push runtime images (requires --tag or --use-git-hash-as-tag)
   --push-force                     Force runtime images, will overwrite images with same tag (requires --tag or --use-git-hash-as-tag)
+  --only-list-artifacts            Print artifact references that would be published and exit without building or pushing
   --tag <tag>                      Tag for runtime images
   --use-git-hash-as-tag            Use the current git hash as tag
   -h, --help                       Brings up this menu
@@ -78,6 +79,10 @@ while [[ $# -gt 0 ]]; do
     force=1
     shift
     ;;
+  --only-list-artifacts)
+    only_list_artifacts=1
+    shift
+    ;;
   --tag)
     image_tag="$2"
     shift 2
@@ -97,6 +102,11 @@ while [[ $# -gt 0 ]]; do
     ;;
   esac
 done
+
+if [[ -n "${only_list_artifacts:-}" && -n "${push:-}" ]]; then
+  echo "ERROR: --only-list-artifacts cannot be used with --push or --push-force"
+  exit 1
+fi
 
 # Ensure registry_dir starts with a /
 if [[ ! "$registry_dir" =~ ^/ ]]; then
@@ -126,6 +136,12 @@ function build_and_push_platform() {
   local image_tag_with_platform="${image_tag}-${platform}"
 
   full_image="${container_registry_fqdn}${registry_dir}${repo}:${image_tag_with_platform}"
+
+  if [[ -n "${only_list_artifacts:-}" ]]; then
+    echo "$full_image"
+    return 0
+  fi
+
   echo "Building image ${full_image}..."
 
   set +e
@@ -169,12 +185,20 @@ function build_and_push() {
     build_and_push_platform "${build_context}" "${dockerfile_path}" "${repo}" "arm64"
   fi
 
+  manifest_name="${container_registry_fqdn}${registry_dir}${repo}:${image_tag}"
+
+  if [[ -n "${only_list_artifacts:-}" ]]; then
+    if [[ -n "${amd64:-}" && -n "${arm64:-}" ]]; then
+      echo "$manifest_name"
+    fi
+    return 0
+  fi
+
   # if not pushing or not building for both platforms, skip  creating a manifest
   if [[ -z "${push:-}" || -z "${amd64:-}" || -z "${arm64:-}" ]]; then
     return 0
   fi
 
-  manifest_name="${container_registry_fqdn}${registry_dir}${repo}:${image_tag}"
   docker manifest create --amend "${manifest_name}" "${container_registry_fqdn}${registry_dir}${repo}:${image_tag}-amd64" "${container_registry_fqdn}${registry_dir}${repo}:${image_tag}-arm64" >/dev/null
 
   # Push manigest
@@ -217,6 +241,12 @@ if [[ -n "${client:-}" ]]; then
 fi
 
 if [[ -n "${helm:-}" ]]; then
+
+  helm_chart_ref="${container_registry_fqdn}${registry_dir}helm/tyger:${image_tag}"
+  if [[ -n "${only_list_artifacts:-}" ]]; then
+    echo "$helm_chart_ref"
+    exit 0
+  fi
 
   # If we are pushing to an Azure Container Registry, we need to do a special login
   if [[ "${container_registry_fqdn}" =~ \.azurecr\.io$ ]]; then


### PR DESCRIPTION
- Move tag-triggered publishing into a dedicated Release workflow so `v*.*.*` pushes no longer run the full CI/deploy/test workflow.
- Add a release sanity check that waits up to 30 minutes for official container images and the Helm chart to become available, checking manifests without pulling layers.
- Add an `--only-list-artifacts` mode to the image build script and a `list-official-artifacts` Make target so release verification uses the same artifact list as official publishing instead of hard-coded image names.
- Switch GoReleaser changelog generation to GitHub-native release notes.
- Update GitHub setup actions to newer versions where touched by the workflow cleanup.