### PR TITLE
Grant AKS managed identity Network Contributor on subnet route table and NAT gateway

### DIFF
--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -209,6 +209,7 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 	var vnetSubnetId *string
 	var vnetSubnetNsgId *string
 	var vnetSubnetRouteTableId *string
+	var vnetSubnetNatGatewayId *string
 	if clusterConfig.ExistingSubnet != nil {
 		vnetClient, err := armnetwork.NewVirtualNetworksClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
 		if err != nil {
@@ -244,6 +245,10 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 
 		if subnet.Properties.RouteTable != nil && subnet.Properties.RouteTable.ID != nil {
 			vnetSubnetRouteTableId = subnet.Properties.RouteTable.ID
+		}
+
+		if subnet.Properties.NatGateway != nil && subnet.Properties.NatGateway.ID != nil {
+			vnetSubnetNatGatewayId = subnet.Properties.NatGateway.ID
 		}
 	}
 
@@ -294,6 +299,12 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 		if vnetSubnetRouteTableId != nil {
 			if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, *vnetSubnetRouteTableId, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
 				return nil, fmt.Errorf("failed to assign Network Contributor role on route table: %w", err)
+			}
+		}
+
+		if vnetSubnetNatGatewayId != nil {
+			if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, *vnetSubnetNatGatewayId, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
+				return nil, fmt.Errorf("failed to assign Network Contributor role on NAT gateway: %w", err)
 			}
 		}
 
@@ -984,6 +995,11 @@ func (inst *Installer) onDeleteCluster(ctx context.Context, clusterConfig *Clust
 					if subnet.Properties.RouteTable != nil && subnet.Properties.RouteTable.ID != nil {
 						if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *subnet.Properties.RouteTable.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
 							return fmt.Errorf("failed to remove RBAC role assignments on subnet route table: %w", err)
+						}
+					}
+					if subnet.Properties.NatGateway != nil && subnet.Properties.NatGateway.ID != nil {
+						if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *subnet.Properties.NatGateway.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
+							return fmt.Errorf("failed to remove RBAC role assignments on subnet NAT gateway: %w", err)
 						}
 					}
 				}

--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -281,36 +281,36 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 		cluster.Properties.APIServerAccessProfile.PrivateDNSZone = &aksPrivateDnsZoneId
 
 		if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, aksPrivateDnsZoneId, "Private DNS Zone Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-			return nil, fmt.Errorf("failed to assign Private DNS Zone Contributor role: %w", err)
+			return nil, fmt.Errorf("failed to assign Private DNS Zone Contributor role on '%s': %w", aksPrivateDnsZoneId, err)
 		}
 
 		if vnetId != nil {
 			if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, *vnetId, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-				return nil, fmt.Errorf("failed to assign Network Contributor role on VNet: %w", err)
+				return nil, fmt.Errorf("failed to assign Network Contributor role on VNet '%s': %w", *vnetId, err)
 			}
 		}
 
 		if vnetSubnetNsgId != nil {
 			if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, *vnetSubnetNsgId, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-				return nil, fmt.Errorf("failed to assign Network Contributor role on NSG: %w", err)
+				return nil, fmt.Errorf("failed to assign Network Contributor role on NSG '%s': %w", *vnetSubnetNsgId, err)
 			}
 		}
 
 		if vnetSubnetRouteTableId != nil {
 			if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, *vnetSubnetRouteTableId, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-				return nil, fmt.Errorf("failed to assign Network Contributor role on route table: %w", err)
+				return nil, fmt.Errorf("failed to assign Network Contributor role on route table '%s': %w", *vnetSubnetRouteTableId, err)
 			}
 		}
 
 		if vnetSubnetNatGatewayId != nil {
 			if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, *vnetSubnetNatGatewayId, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-				return nil, fmt.Errorf("failed to assign Network Contributor role on NAT gateway: %w", err)
+				return nil, fmt.Errorf("failed to assign Network Contributor role on NAT gateway '%s': %w", *vnetSubnetNatGatewayId, err)
 			}
 		}
 
 		if outboundIpAddress != nil {
 			if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, *outboundIpAddress.ID, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-				return nil, fmt.Errorf("failed to assign Network Contributor role on outbound IP: %w", err)
+				return nil, fmt.Errorf("failed to assign Network Contributor role on outbound IP '%s': %w", *outboundIpAddress.ID, err)
 			}
 		}
 	}
@@ -542,14 +542,14 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 	}
 
 	if err := assignRbacRole(ctx, inst.Config.Cloud.Compute.GetManagementPrincipalIds(), true, *createdCluster.ID, "Azure Kubernetes Service Cluster User Role", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-		return nil, fmt.Errorf("failed to assign RBAC role on cluster: %w", err)
+		return nil, fmt.Errorf("failed to assign Azure Kubernetes Service Cluster User Role on cluster '%s': %w", *createdCluster.ID, err)
 	}
 
 	// When using private networking, RBAC roles were pre-assigned to the user-assigned identity.
 	// When not using private networking, assign roles to the system-assigned identity post-creation.
 	if !inst.Config.Cloud.PrivateNetworking && outboundIpAddress != nil {
 		if err := assignRbacRole(ctx, []string{*createdCluster.Identity.PrincipalID}, false, *outboundIpAddress.ID, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-			return nil, fmt.Errorf("failed to assign RBAC role on outbound IP address: %w", err)
+			return nil, fmt.Errorf("failed to assign Network Contributor role on outbound IP '%s': %w", *outboundIpAddress.ID, err)
 		}
 	}
 
@@ -979,7 +979,7 @@ func (inst *Installer) onDeleteCluster(ctx context.Context, clusterConfig *Clust
 
 			if clusterPrincipalID != "" {
 				if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *vnet.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-					return fmt.Errorf("failed to remove RBAC role assignments on VNet: %w", err)
+					return fmt.Errorf("failed to remove RBAC role assignments on VNet '%s': %w", *vnet.ID, err)
 				}
 				subnetIndex := slices.IndexFunc(vnet.Properties.Subnets, func(s *armnetwork.Subnet) bool {
 					return s.Name != nil && *s.Name == clusterConfig.ExistingSubnet.SubnetName
@@ -989,17 +989,17 @@ func (inst *Installer) onDeleteCluster(ctx context.Context, clusterConfig *Clust
 					subnet := vnet.Properties.Subnets[subnetIndex]
 					if subnet.Properties.NetworkSecurityGroup != nil && subnet.Properties.NetworkSecurityGroup.ID != nil {
 						if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *subnet.Properties.NetworkSecurityGroup.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-							return fmt.Errorf("failed to remove RBAC role assignments on subnet NSG: %w", err)
+							return fmt.Errorf("failed to remove RBAC role assignments on subnet NSG '%s': %w", *subnet.Properties.NetworkSecurityGroup.ID, err)
 						}
 					}
 					if subnet.Properties.RouteTable != nil && subnet.Properties.RouteTable.ID != nil {
 						if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *subnet.Properties.RouteTable.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-							return fmt.Errorf("failed to remove RBAC role assignments on subnet route table: %w", err)
+							return fmt.Errorf("failed to remove RBAC role assignments on subnet route table '%s': %w", *subnet.Properties.RouteTable.ID, err)
 						}
 					}
 					if subnet.Properties.NatGateway != nil && subnet.Properties.NatGateway.ID != nil {
 						if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *subnet.Properties.NatGateway.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
-							return fmt.Errorf("failed to remove RBAC role assignments on subnet NAT gateway: %w", err)
+							return fmt.Errorf("failed to remove RBAC role assignments on subnet NAT gateway '%s': %w", *subnet.Properties.NatGateway.ID, err)
 						}
 					}
 				}

--- a/cli/internal/install/cloudinstall/compute.go
+++ b/cli/internal/install/cloudinstall/compute.go
@@ -208,6 +208,7 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 	var vnetId *string
 	var vnetSubnetId *string
 	var vnetSubnetNsgId *string
+	var vnetSubnetRouteTableId *string
 	if clusterConfig.ExistingSubnet != nil {
 		vnetClient, err := armnetwork.NewVirtualNetworksClient(inst.Config.Cloud.SubscriptionID, inst.Credential, nil)
 		if err != nil {
@@ -239,6 +240,10 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 			vnetSubnetNsgId = subnet.Properties.NetworkSecurityGroup.ID
 		} else {
 			return nil, fmt.Errorf("subnet '%s' must have a network security group associated with it", clusterConfig.ExistingSubnet.SubnetName)
+		}
+
+		if subnet.Properties.RouteTable != nil && subnet.Properties.RouteTable.ID != nil {
+			vnetSubnetRouteTableId = subnet.Properties.RouteTable.ID
 		}
 	}
 
@@ -283,6 +288,12 @@ func (inst *Installer) createCluster(ctx context.Context, clusterConfig *Cluster
 		if vnetSubnetNsgId != nil {
 			if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, *vnetSubnetNsgId, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
 				return nil, fmt.Errorf("failed to assign Network Contributor role on NSG: %w", err)
+			}
+		}
+
+		if vnetSubnetRouteTableId != nil {
+			if err := assignRbacRole(ctx, []string{*aksIdentity.Properties.PrincipalID}, false, *vnetSubnetRouteTableId, "Network Contributor", inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
+				return nil, fmt.Errorf("failed to assign Network Contributor role on route table: %w", err)
 			}
 		}
 
@@ -968,6 +979,11 @@ func (inst *Installer) onDeleteCluster(ctx context.Context, clusterConfig *Clust
 					if subnet.Properties.NetworkSecurityGroup != nil && subnet.Properties.NetworkSecurityGroup.ID != nil {
 						if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *subnet.Properties.NetworkSecurityGroup.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
 							return fmt.Errorf("failed to remove RBAC role assignments on subnet NSG: %w", err)
+						}
+					}
+					if subnet.Properties.RouteTable != nil && subnet.Properties.RouteTable.ID != nil {
+						if err := removeRbacRoleAssignments(ctx, clusterPrincipalID, *subnet.Properties.RouteTable.ID, inst.Config.Cloud.SubscriptionID, inst.Credential); err != nil {
+							return fmt.Errorf("failed to remove RBAC role assignments on subnet route table: %w", err)
 						}
 					}
 				}


### PR DESCRIPTION
When private networking is enabled with a pre-existing subnet that has a user-defined route table attached (e.g., for routing default egress through a peered hub VNet), installation/upgrade could later fail with a `LinkedAuthorizationFailed` error from the AKS cloud-controller-manager:

```
Error syncing load balancer: failed to ensure load balancer:
PUT .../virtualNetworks/<vnet>/subnets/snet-aks
RESPONSE 403: 403 Forbidden
ERROR CODE: LinkedAuthorizationFailed

The client '<...>' with object id '<...>' has permission to perform action
'Microsoft.Network/virtualNetworks/subnets/write' on scope '.../subnets/snet-aks';
however, it does not have permission to perform action(s)
'Microsoft.Network/routeTables/join/action' on the linked scope(s)
'.../routeTables/udr-default-vnet-peered-001'
```

Azure Resource Manager performs a *linked authorization* check whenever a write occurs on a subnet: the calling principal must hold `join/action` on every resource the subnet references (NSG, route table, NAT gateway, etc.). The installer was already granting the AKS cluster's user-assigned managed identity `Network Contributor` on the VNet, the subnet's NSG, and the outbound public IP, but not on the route table or NAT gateway.