### PR TITLE
Cancel pending runs that exceed their timeout

### DIFF
--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -1879,6 +1879,51 @@ func TestCancelRun(t *testing.T) {
 	require.Equal("Canceled by user", run.StatusReason)
 }
 
+// Verifies that a run that is stuck in the Pending state (because the pod is
+// unschedulable) is automatically canceled by the control plane once its
+// timeoutSeconds has elapsed. This guards against resource lock-up scenarios
+// (most importantly distributed runs whose worker StatefulSet would otherwise
+// hold capacity indefinitely), where Kubernetes's pod-level
+// activeDeadlineSeconds never starts counting because the kubelet never admits
+// the pod.
+func TestPendingRunIsCanceledWhenTimeoutExpires(t *testing.T) {
+	t.Parallel()
+	skipIfOnlyFastTests(t)
+	skipIfUsingDockerUrl(t)
+	require := require.New(t)
+
+	// Request an absurd amount of CPU so the pod cannot be scheduled and the
+	// run stays in the Pending state. timeoutSeconds is short so the
+	// RunTimeoutEnforcer cancels the run quickly.
+	runSpec := fmt.Sprintf(`
+job:
+  codespec:
+    image: %s
+    command: ["sleep", "1h"]
+    resources:
+      requests:
+        cpu: "10000"
+timeoutSeconds: 5`, BasicImage)
+
+	tempDir := t.TempDir()
+	runSpecPath := filepath.Join(tempDir, "runspec.yaml")
+	require.NoError(os.WriteFile(runSpecPath, []byte(runSpec), 0644))
+
+	runId := runTygerSucceeds(t, "run", "create", "--file", runSpecPath)
+	t.Logf("Run ID: %s", runId)
+
+	// The run should be Pending immediately after creation; the enforcer only
+	// targets Pending runs.
+	require.Equal(model.Pending, *getRun(t, runId).Status)
+
+	// The enforcer polls on a 60s cadence, so allow ample time for it to
+	// observe the expiration and cancel the run.
+	run := waitForRunCanceled(t, runId)
+
+	require.Equal(model.Canceled, *run.Status)
+	require.Contains(run.StatusReason, "timeout")
+}
+
 func TestCancelTerminatesOutputBuffers(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -1889,7 +1889,7 @@ func TestCancelRun(t *testing.T) {
 func TestPendingRunIsCanceledWhenTimeoutExpires(t *testing.T) {
 	t.Parallel()
 	skipIfOnlyFastTests(t)
-	skipIfUsingDockerUrl(t)
+	skipIfUsingUnixSocket(t)
 	require := require.New(t)
 
 	// Request an absurd amount of CPU so the pod cannot be scheduled and the

--- a/server/ControlPlane/Compute/Compute.cs
+++ b/server/ControlPlane/Compute/Compute.cs
@@ -13,6 +13,8 @@ public static class Compute
         builder.Services.AddSingleton<RunSecretUpdater>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<RunSecretUpdater>());
 
+        builder.Services.AddHostedService<RunTimeoutEnforcer>();
+
         var kubernetesSection = builder.Configuration.GetSection("compute:kubernetes");
         var dockerSection = builder.Configuration.GetSection("compute:docker");
         switch (kubernetesSection.Exists(), dockerSection.Exists())

--- a/server/ControlPlane/Compute/Docker/DockerRunUpdater.cs
+++ b/server/ControlPlane/Compute/Docker/DockerRunUpdater.cs
@@ -37,10 +37,10 @@ public class DockerRunUpdater : IRunUpdater
         _bufferProvider = bufferProvider;
     }
 
-    public async Task<Run?> CancelRun(long id, CancellationToken cancellationToken)
+    public async Task<Run?> CancelRun(long id, string statusReason, CancellationToken cancellationToken)
     {
         _logger.CancelingRun(id);
-        var updatedRun = await _repository.CancelRun(id, cancellationToken: cancellationToken);
+        var updatedRun = await _repository.CancelRun(id, statusReason, cancellationToken: cancellationToken);
         if (updatedRun is null)
         {
             return null;

--- a/server/ControlPlane/Compute/Kubernetes/KubernetesRunUpdater.cs
+++ b/server/ControlPlane/Compute/Kubernetes/KubernetesRunUpdater.cs
@@ -20,10 +20,10 @@ public class KubernetesRunUpdater : IRunUpdater
         _logger = logger;
     }
 
-    public async Task<Run?> CancelRun(long id, CancellationToken cancellationToken)
+    public async Task<Run?> CancelRun(long id, string statusReason, CancellationToken cancellationToken)
     {
         _logger.CancelingRun(id);
-        return await _repository.CancelRun(id, cancellationToken);
+        return await _repository.CancelRun(id, statusReason, cancellationToken);
     }
 
     public async Task<UpdateWithPreconditionResult<Run>> UpdateRunTags(RunUpdate runUpdate, string? eTagPrecondition, CancellationToken cancellationToken)

--- a/server/ControlPlane/Compute/LoggerExtensions.cs
+++ b/server/ControlPlane/Compute/LoggerExtensions.cs
@@ -52,4 +52,13 @@ public static partial class LoggerExtensions
 
     [LoggerMessage(LogLevel.Error, "Error during secret update")]
     public static partial void ErrorInRunSecretUpdater(this ILogger logger, Exception e);
+
+    [LoggerMessage(LogLevel.Information, "Canceled run {runId} because it exceeded its timeout")]
+    public static partial void CanceledExpiredRun(this ILogger logger, long runId);
+
+    [LoggerMessage(LogLevel.Error, "Error canceling expired run {runId}")]
+    public static partial void ErrorCancelingExpiredRun(this ILogger logger, Exception e, long runId);
+
+    [LoggerMessage(LogLevel.Error, "Error in run timeout enforcer")]
+    public static partial void ErrorInRunTimeoutEnforcer(this ILogger logger, Exception e);
 }

--- a/server/ControlPlane/Compute/RunTimeoutEnforcer.cs
+++ b/server/ControlPlane/Compute/RunTimeoutEnforcer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Tyger.ControlPlane.Database;
+using Tyger.ControlPlane.Model;
 using Tyger.ControlPlane.Runs;
 
 namespace Tyger.ControlPlane.Compute;
@@ -74,7 +75,14 @@ public class RunTimeoutEnforcer : BackgroundService
             {
                 try
                 {
-                    if (await _runUpdater.CancelRun(id, TimeoutStatusReason, cancellationToken) is not null)
+                    // CancelRun returns the run unchanged if it is already terminal/final,
+                    // so the loop may race with another cancellation path between the
+                    // GetExpiredPendingRunIds query and this call. Only log a successful
+                    // cancellation when the returned run actually reflects our update
+                    // (Canceled with our reason); otherwise some other path got there
+                    // first and there is nothing for us to report.
+                    var canceled = await _runUpdater.CancelRun(id, TimeoutStatusReason, cancellationToken);
+                    if (canceled is { Status: RunStatus.Canceled, StatusReason: TimeoutStatusReason })
                     {
                         _logger.CanceledExpiredRun(id);
                     }

--- a/server/ControlPlane/Compute/RunTimeoutEnforcer.cs
+++ b/server/ControlPlane/Compute/RunTimeoutEnforcer.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Tyger.ControlPlane.Database;
+using Tyger.ControlPlane.Runs;
+
+namespace Tyger.ControlPlane.Compute;
+
+/// <summary>
+/// Periodically scans the database for runs that are still in the
+/// <see cref="Model.RunStatus.Pending"/> state and whose
+/// <c>timeoutSeconds</c> has elapsed (measured from <c>created_at</c>), and
+/// cancels them.
+///
+/// This backstops the underlying compute platform for the case where it cannot
+/// enforce the timeout itself. In particular, a Kubernetes Pod that is stuck
+/// in <c>Pending</c> (e.g. unschedulable due to insufficient capacity) never
+/// gets a <c>StartTime</c>, so the kubelet's <c>activeDeadlineSeconds</c>
+/// never begins counting and reserved worker resources can be held
+/// indefinitely. Once a Pod is admitted by the kubelet, the kubelet enforces
+/// the deadline, so Running runs are intentionally not handled here.
+///
+/// The database is the source of truth: the next-due cancellation time is
+/// recomputed from stored fields on every poll rather than tracked in memory.
+/// </summary>
+public class RunTimeoutEnforcer : BackgroundService
+{
+    private static readonly TimeSpan s_pollInterval = TimeSpan.FromSeconds(60);
+    private const string TimeoutStatusReason = "Run exceeded its timeout while pending";
+    private const int BatchSize = 100;
+
+    private readonly Repository _repository;
+    private readonly IRunUpdater _runUpdater;
+    private readonly ILogger<RunTimeoutEnforcer> _logger;
+
+    public RunTimeoutEnforcer(Repository repository, IRunUpdater runUpdater, ILogger<RunTimeoutEnforcer> logger)
+    {
+        _repository = repository;
+        _runUpdater = runUpdater;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(s_pollInterval, stoppingToken);
+                await CancelExpiredPendingRuns(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception e)
+            {
+                _logger.ErrorInRunTimeoutEnforcer(e);
+            }
+        }
+    }
+
+    private async Task CancelExpiredPendingRuns(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var expiredIds = await _repository.GetExpiredPendingRunIds(BatchSize, cancellationToken);
+            if (expiredIds.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var id in expiredIds)
+            {
+                try
+                {
+                    if (await _runUpdater.CancelRun(id, TimeoutStatusReason, cancellationToken) is not null)
+                    {
+                        _logger.CanceledExpiredRun(id);
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception e)
+                {
+                    _logger.ErrorCancelingExpiredRun(e, id);
+                }
+            }
+
+            if (expiredIds.Count < BatchSize)
+            {
+                return;
+            }
+        }
+    }
+}

--- a/server/ControlPlane/Compute/RunTimeoutEnforcer.cs
+++ b/server/ControlPlane/Compute/RunTimeoutEnforcer.cs
@@ -9,7 +9,7 @@ namespace Tyger.ControlPlane.Compute;
 
 /// <summary>
 /// Periodically scans the database for runs that are still in the
-/// <see cref="Model.RunStatus.Pending"/> state and whose
+/// <see cref="RunStatus.Pending"/> state and whose
 /// <c>timeoutSeconds</c> has elapsed (measured from <c>created_at</c>), and
 /// cancels them.
 ///

--- a/server/ControlPlane/Database/Repository.cs
+++ b/server/ControlPlane/Database/Repository.cs
@@ -2454,6 +2454,21 @@ public class Repository
         }
     }
 
+    /// <summary>
+    /// Returns all runs that have reached a terminal status but have not yet
+    /// been marked as <c>final</c> by the finalizer. This is used as a
+    /// lease-acquisition fallback for runs whose <c>run_changed</c> notification
+    /// was missed (e.g. because the listening replica was down at the moment
+    /// the run transitioned).
+    ///
+    /// We deliberately do NOT filter on <c>resources_created = true</c>: a
+    /// Pending run that is canceled (for example by
+    /// <see cref="Compute.RunTimeoutEnforcer"/>) before its
+    /// Kubernetes resources were created still needs to be marked final so it
+    /// doesn't accumulate in the table. The Kubernetes deletion path in
+    /// <c>RunFinalizer</c> handles missing resources gracefully (404 responses
+    /// are ignored).
+    /// </summary>
     public async Task<List<Run>> GetFinalizableRuns(CancellationToken cancellationToken)
     {
         return await _resiliencePipeline.ExecuteAsync(async cancellationToken =>
@@ -2467,7 +2482,7 @@ public class Repository
                 CommandText = """
                     SELECT run
                     FROM runs
-                    WHERE final = false AND resources_created = true AND status IN ('Failed', 'Succeeded', 'Canceled')
+                    WHERE final = false AND status IN ('Failed', 'Succeeded', 'Canceled')
                     ORDER BY created_at ASC
                     """
             })

--- a/server/ControlPlane/Database/Repository.cs
+++ b/server/ControlPlane/Database/Repository.cs
@@ -257,7 +257,15 @@ public class Repository
     {
         return await _resiliencePipeline.ExecuteAsync(async cancellationToken =>
         {
-            newRun = newRun.WithoutSystemProperties() with { Status = RunStatus.Pending };
+            newRun = newRun.WithoutSystemProperties() with
+            {
+                Status = RunStatus.Pending,
+                // Ensure the run always has a timeout persisted so RunTimeoutEnforcer
+                // can detect expired Pending runs. A client that omits the field gets
+                // the default from the Run record; a client that explicitly sends null
+                // is coerced here.
+                TimeoutSeconds = newRun.TimeoutSeconds ?? Run.DefaultTimeoutSeconds,
+            };
 
             await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
             await using var tx = await connection.BeginTransactionAsync(cancellationToken);
@@ -509,7 +517,7 @@ public class Repository
         }, cancellationToken);
     }
 
-    public async Task<Run?> CancelRun(long id, CancellationToken cancellationToken)
+    public async Task<Run?> CancelRun(long id, string statusReason, CancellationToken cancellationToken)
     {
         return await _resiliencePipeline.ExecuteAsync(async cancellationToken =>
         {
@@ -554,7 +562,7 @@ public class Repository
             var updatedRun = run with
             {
                 Status = RunStatus.Canceled,
-                StatusReason = "Canceled by user",
+                StatusReason = statusReason,
                 FinishedAt = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second, now.Offset),
             };
 
@@ -2473,6 +2481,52 @@ public class Repository
             }
 
             return runs;
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Returns the IDs of runs that are still in the <c>Pending</c> state
+    /// whose timeout has elapsed, measured from the run's <c>created_at</c>
+    /// timestamp using the <c>timeoutSeconds</c> value stored in the run JSON.
+    /// At most <paramref name="limit"/> IDs are returned.
+    ///
+    /// Running runs are not included here: once a Kubernetes pod is admitted
+    /// by the kubelet, the pod's <c>activeDeadlineSeconds</c> enforces the
+    /// timeout. Pending runs (e.g. pods that are unschedulable due to
+    /// insufficient capacity) never get a <c>StartTime</c>, so the kubelet's
+    /// deadline never begins counting and the control plane must enforce it.
+    /// </summary>
+    public async Task<List<long>> GetExpiredPendingRunIds(int limit, CancellationToken cancellationToken)
+    {
+        return await _resiliencePipeline.ExecuteAsync(async cancellationToken =>
+        {
+            await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+
+            var ids = new List<long>();
+            using (var command = new NpgsqlCommand
+            {
+                Connection = connection,
+                CommandText = """
+                    SELECT id
+                    FROM runs
+                    WHERE final = false
+                      AND status = 'Pending'
+                      AND created_at + ((run->>'timeoutSeconds')::int * interval '1 second') <= (now() AT TIME ZONE 'utc')
+                    ORDER BY created_at ASC
+                    LIMIT $1
+                    """,
+                Parameters = { new() { Value = limit, NpgsqlDbType = NpgsqlDbType.Integer } }
+            })
+            {
+                await command.PrepareAsync(cancellationToken);
+                await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    ids.Add(reader.GetInt64(0));
+                }
+            }
+
+            return ids;
         }, cancellationToken);
     }
 

--- a/server/ControlPlane/Database/Repository.cs
+++ b/server/ControlPlane/Database/Repository.cs
@@ -524,10 +524,9 @@ public class Repository
             await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken);
             await using var tx = await conn.BeginTransactionAsync(cancellationToken);
             Run run;
-            bool resourcesCreated;
             int tagsVersion;
             await using (var readRun = new NpgsqlCommand($"""
-                SELECT run, resources_created, final, tags_version
+                SELECT run, final, tags_version
                 FROM runs
                 WHERE id = $1
                 FOR UPDATE
@@ -547,15 +546,14 @@ public class Repository
                 }
 
                 run = reader.GetFieldValue<Run>(0);
-                resourcesCreated = reader.GetBoolean(1);
-                var final = reader.GetBoolean(2);
+                var final = reader.GetBoolean(1);
 
                 if (final || run.Status.IsTerminal())
                 {
                     return run;
                 }
 
-                tagsVersion = reader.GetInt32(3);
+                tagsVersion = reader.GetInt32(2);
             }
 
             var now = DateTimeOffset.UtcNow;
@@ -2510,6 +2508,11 @@ public class Repository
     /// timeout. Pending runs (e.g. pods that are unschedulable due to
     /// insufficient capacity) never get a <c>StartTime</c>, so the kubelet's
     /// deadline never begins counting and the control plane must enforce it.
+    ///
+    /// Rows whose <c>timeoutSeconds</c> is missing or JSON null are treated as
+    /// if they had <see cref="Run.DefaultTimeoutSeconds"/>. This matches the
+    /// coercion applied at create time and ensures legacy rows written before
+    /// that coercion still get enforced.
     /// </summary>
     public async Task<List<long>> GetExpiredPendingRunIds(int limit, CancellationToken cancellationToken)
     {
@@ -2526,11 +2529,15 @@ public class Repository
                     FROM runs
                     WHERE final = false
                       AND status = 'Pending'
-                      AND created_at + ((run->>'timeoutSeconds')::int * interval '1 second') <= (now() AT TIME ZONE 'utc')
+                      AND created_at + (COALESCE((run->>'timeoutSeconds')::int, $2) * interval '1 second') <= (now() AT TIME ZONE 'utc')
                     ORDER BY created_at ASC
                     LIMIT $1
                     """,
-                Parameters = { new() { Value = limit, NpgsqlDbType = NpgsqlDbType.Integer } }
+                Parameters =
+                {
+                    new() { Value = limit, NpgsqlDbType = NpgsqlDbType.Integer },
+                    new() { Value = Run.DefaultTimeoutSeconds, NpgsqlDbType = NpgsqlDbType.Integer },
+                }
             })
             {
                 await command.PrepareAsync(cancellationToken);

--- a/server/ControlPlane/Model/Model.cs
+++ b/server/ControlPlane/Model/Model.cs
@@ -550,9 +550,15 @@ public partial record Run : ModelBase
     public RunCodeTarget? Worker { get; init; }
 
     /// <summary>
+    /// The default value applied to <see cref="TimeoutSeconds"/> when a client does
+    /// not supply one (or supplies an explicit null).
+    /// </summary>
+    public const int DefaultTimeoutSeconds = 12 * 60 * 60;
+
+    /// <summary>
     /// The maximum number of seconds to wait for the run to complete. If the run does not complete within this time, it will be canceled.
     /// </summary>
-    public int? TimeoutSeconds { get; init; } = (int)TimeSpan.FromHours(12).TotalSeconds;
+    public int? TimeoutSeconds { get; init; } = DefaultTimeoutSeconds;
 
     /// <summary>
     /// The name of target cluster.

--- a/server/ControlPlane/Runs/Runs.cs
+++ b/server/ControlPlane/Runs/Runs.cs
@@ -211,7 +211,7 @@ public static class Runs
                 return Responses.NotFound();
             }
 
-            if (await runUpdater.CancelRun(parsedRunId, context.RequestAborted) is not Run run)
+            if (await runUpdater.CancelRun(parsedRunId, "Canceled by user", context.RequestAborted) is not Run run)
             {
                 return Responses.NotFound();
             }
@@ -290,7 +290,7 @@ public interface IRunReader
 
 public interface IRunUpdater
 {
-    Task<Run?> CancelRun(long id, CancellationToken cancellationToken);
+    Task<Run?> CancelRun(long id, string statusReason, CancellationToken cancellationToken);
     Task<UpdateWithPreconditionResult<Run>> UpdateRunTags(RunUpdate runUpdate, string? eTagPrecondition, CancellationToken cancellationToken);
 }
 


### PR DESCRIPTION
## Problem

`Run.TimeoutSeconds` is enforced by setting `pod.spec.activeDeadlineSeconds` on the job pod. However, the kubelet only begins counting against this deadline once it sets `pod.status.startTime` — which only happens when the pod is admitted. **A Pending pod that is never schedulable (e.g. unsatisfiable resource request, no matching node pool) sits indefinitely with no timeout enforcement.**

In the distributed-run case this is worse: the worker `StatefulSet` is created before the job pod is admitted, so its replicas can reserve cluster capacity (CPU/memory/GPU) for a job that will never start, with no automatic recovery.

## Fix

Add a `RunTimeoutEnforcer` `BackgroundService` that periodically polls the database for `Pending` runs whose `created_at + timeoutSeconds` is in the past and cancels them via `IRunUpdater`.

The database is the source of truth — expiration is recomputed from stored fields on every poll rather than tracked in memory, so the behavior is correct across restarts and replicas.

Scoped to `Pending` only. Once the kubelet admits a pod, its `activeDeadlineSeconds` takes over and we don't want to race with it.

## Compatibility notes

- API behavior change: a client explicitly sending `"timeoutSeconds": null` previously meant "no timeout enforcement"; it now gets the 12-hour default. Clients that *omit* the field are unaffected. The Go CLI uses `*int` with `omitempty` and is unaffected. Worth a release-notes mention.
- No schema migration required.
