### PR TITLE
Add `tyger login --az` (Azure CLI login)

### DIFF
--- a/.devcontainer/devcontainer-on-create.sh
+++ b/.devcontainer/devcontainer-on-create.sh
@@ -9,16 +9,12 @@ set -euo pipefail
 
 # If this is not an Azure VM, add a firewall rule to the deployment config
 # so this machine's external IP will be able to access the database.
-# Also override TYGER_AUTH_METHOD to cert since managed identity is not available.
 if ! curl -s --fail -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" --connect-timeout 2; then
     echo "Not an Azure VM. Adding firewall rule to allow access to database."
 
     ip=$(curl -s --fail https://ipinfo.io/ip)
 
     echo "export TYGER_ENVIRONMENT_FIREWALL_RULES=\"[{ \\\"name\\\": \\\"devcontainer\\\", \\\"startIpAddress\\\": \\\"$ip\\\", \\\"endIpAddress\\\": \\\"$ip\\\"}]\"" |
-        sudo tee -a /opt/devcontainer/devcontainer.bashrc >/dev/null
-
-    echo "export TYGER_AUTH_METHOD=cert" |
         sudo tee -a /opt/devcontainer/devcontainer.bashrc >/dev/null
 fi
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -92,7 +92,7 @@
     "DEVCONTAINER_HOST_HOME": "${localEnv:HOME}",
     "TYGER_ACCESSING_FROM_DOCKER": "1",
     "TYGER_DOCKER_HOST_PATH_TRANSLATIONS": "${containerWorkspaceFolder}=${localWorkspaceFolder}",
-    "TYGER_AUTH_METHOD": "identity"
+    "TYGER_AUTH_METHOD": "az"
   },
 
   "forwardPorts": [

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,8 +2,8 @@
 
 Tyger is a REST API and CLI for **remote signal processing**. It accepts streaming
 input, runs containerized user code on Kubernetes (cloud) or Docker (local), and
-exposes the results via WORM data streams ("buffers"). It is deployed an
-ASP.NET Core control-plane service (and a data plane service in local mode) plus
+exposes the results via WORM data streams ("buffers"). It is deployed as an
+ASP.NET Core control-plane service, a data plane service in local mode, plus
 a set of Go-based CLIs and sidecars.
 
 Always read the surrounding code before changing it, and prefer minimal,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,255 @@
+# Tyger — Copilot Instructions
+
+Tyger is a REST API and CLI for **remote signal processing**. It accepts streaming
+input, runs containerized user code on Kubernetes (cloud) or Docker (local), and
+exposes the results via WORM data streams ("buffers"). It is deployed as two
+ASP.NET Core services (a control plane and a data plane) plus a set of Go-based
+CLIs and sidecars.
+
+Always read the surrounding code before changing it, and prefer minimal,
+targeted edits that match the conventions described below.
+
+## Repository layout
+
+| Path | Purpose |
+| --- | --- |
+| [server/](../server/) | .NET 10 solution ([tyger.sln](../server/tyger.sln)) |
+| [server/ControlPlane/](../server/ControlPlane/) | `tyger-server` — runs jobs, manages codespecs/runs/buffers |
+| [server/DataPlane/](../server/DataPlane/) | `tyger-data-plane` — local buffer I/O endpoint (Docker mode) |
+| [server/Common/](../server/Common/) | Shared library (configuration, middleware, versioning, UDS) |
+| [server/ControlPlane.UnitTests/](../server/ControlPlane.UnitTests/) | xUnit tests for the control plane |
+| [cli/](../cli/) | Go module `github.com/microsoft/tyger/cli` (Go 1.26+) |
+| [cli/cmd/tyger/](../cli/cmd/tyger/) | The `tyger` CLI entry point (cobra) |
+| [cli/cmd/tyger-proxy/](../cli/cmd/tyger-proxy/) | Local HTTP/Unix-socket proxy to a remote Tyger API |
+| [cli/cmd/buffer-sidecar/](../cli/cmd/buffer-sidecar/) | Sidecar that bridges named pipes <-> buffer storage |
+| [cli/cmd/buffer-copier/](../cli/cmd/buffer-copier/) | Server-side cross-region buffer replication |
+| [cli/cmd/worker-waiter/](../cli/cmd/worker-waiter/) | Init container for distributed runs |
+| [cli/cmd/loader/](../cli/cmd/loader/) | Load/perf testing utility |
+| [cli/integrationtest/](../cli/integrationtest/) | End-to-end tests (build tag `integrationtest`) |
+| [cli/internal/install/](../cli/internal/install/) | `cloudinstall` (AKS/Azure) and `dockerinstall` (local) installers |
+| [scripts/](../scripts/) | Shell helpers used by the Makefiles |
+| [deploy/config/microsoft/](../deploy/config/microsoft/) | Source-of-truth dev/cloud/docker config templates |
+| [deploy/helm/tyger/](../deploy/helm/tyger/) | Helm chart published with releases |
+| [.devcontainer/](../.devcontainer/) | Dev container (Ubuntu + .NET + Go + Azure CLI + kubectl + helm) |
+
+## Toolchain
+
+- **.NET SDK** pinned in [server/global.json](../server/global.json) (`net10.0`,
+  Nullable on, `TreatWarningsAsErrors=true`, `AnalysisMode=Recommended`,
+  `RestorePackagesWithLockFile=true`). When you add or upgrade NuGet packages,
+  update the corresponding `packages.lock.json` (run `make restore`).
+- **Go** version is in [cli/go.mod](../cli/go.mod). Modules use a lock file
+  (`go.sum`); run `go mod tidy` after dependency changes.
+- **System tools** assumed on `PATH`: `make`, `bash`, `jq`, `yq`, `docker`,
+  `kubectl`, `helm`, `az`, `psql`. The devcontainer installs all of these.
+
+## Build, test, and format
+
+The top-level [Makefile](../Makefile) is the canonical entry point for almost
+every task. It selects between [Makefile.cloud](../Makefile.cloud) (default) and
+[Makefile.docker](../Makefile.docker) based on the `TYGER_ENVIRONMENT_TYPE`
+environment variable (`cloud` or `docker`). Some targets only exist in one of
+the two; check both files before assuming a target is missing.
+
+Common targets:
+
+| Target | What it does |
+| --- | --- |
+| `make build` | `dotnet build server/tyger.sln` + `go build ./...` |
+| `make build-csharp` / `make build-go` | One side only |
+| `make restore` | `dotnet restore` + `go mod download` |
+| `make format` | `dotnet format` (do this before pushing C# changes) |
+| `make verify-format` | What CI runs; also enforces analyzer warnings |
+| `make unit-test` | Runs all `*.csproj` tests and `go test ./...` (excludes the `integrationtest` build tag) |
+| `make integration-test` | Brings the environment `up` and runs `cli/integrationtest` with `-tags=integrationtest` |
+| `make integration-test-no-up` | Skips `up`; assumes a running deployment |
+| `make integration-test-fast-only` | Adds `-fast` (skips long-running scenarios) |
+| `make up` / `make down` | Install/uninstall Tyger into the target environment |
+| `make install-cli` | `go install` the `tyger`, `tyger-proxy`, `buffer-sidecar` binaries with version + container image metadata baked in via `-ldflags` |
+| `make run` | Run the control plane locally (after `make set-localsettings`) |
+| `make full` | `make test INSTALL_CLOUD=true` (full CI-style run) |
+| `make pretty-print-config-templates` | Regenerate the canonical config YAML; CI fails if the result differs |
+
+Run the VS Code task `build` for fast incremental C# builds with the
+`$msCompile` problem matcher (see [.vscode/tasks.json](../.vscode/tasks.json)).
+
+The Go integration tests **require the `integrationtest` build tag**
+(`go test -tags=integrationtest ./...` from `cli/integrationtest`). The
+devcontainer's `gopls` is already configured with this tag.
+
+## Typical inner-loop workflows
+
+- **Changing Go code (CLI, sidecars, installers).** Edit, then
+  `make install-cli` to rebuild and reinstall the `tyger`, `tyger-proxy`, and
+  `buffer-sidecar` binaries on `$PATH` (with the right `-ldflags` baked in),
+  then exercise the change by running `tyger ...` (or `tyger-proxy ...` /
+  `buffer-sidecar ...`) directly. No `make up` is needed unless the change
+  also requires a redeployed server.
+- **Changing server code (C#).** The normal loop is `make up`, which builds
+  and pushes the server image and (re)deploys it via Helm/Docker, then run
+  `tyger ...` against it. For very fast inner iteration you can instead run
+  the control plane locally with `make set-localsettings && make run` and
+  point `tyger login` at `http://localhost:5000` (cloud) or the local Unix
+  socket (docker).
+- **Changing the API contract** (anything that touches DTOs, route handlers,
+  or the OpenAPI surface): update both the C# model in
+  `server/ControlPlane/Model/` and the Go model in
+  [cli/internal/controlplane/model/](../cli/internal/controlplane/model/),
+  bump the API version if it's a breaking change, then run
+  `make integration-test-no-up-fast-only` so the OpenAPI snapshot diff runs.
+
+## Coding conventions
+
+### General
+
+- Every source file has the standard MIT copyright header. If you create a new
+  `.cs`, `.go`, `.sh`, `.ps1`/`.psm1`, or `Makefile`, add the matching header —
+  [scripts/add-copyright-headers.sh](../scripts/add-copyright-headers.sh) can
+  add missing headers automatically.
+- `.editorconfig` is authoritative: 4-space indent for C#, tabs preserved in
+  Makefiles, trim trailing whitespace, final newline required.
+- Don't introduce new top-level dependencies casually — both projects use
+  lockfiles and the dependency graph is reviewed.
+
+### C# (server)
+
+- Targets `net10.0`, nullable reference types enabled. Treat any new warning as
+  a build break locally (`make verify-format` uses `-p:EnforceCodeStyleInBuild=true`).
+- Naming (enforced by `.editorconfig`):
+  - Public/protected/internal members: `PascalCase`.
+  - Instance fields: `_camelCase` (leading underscore).
+  - Static fields: `s_camelCase`.
+  - Constants & non-private readonly fields: `PascalCase`.
+  - Locals and parameters: `camelCase`.
+- Use file-scoped namespaces, simple `using` statements, pattern matching,
+  collection/object initializers, and predefined type keywords (`int`, not
+  `Int32`). The analyzers will flag the alternatives.
+- Wire new services through the existing `builder.AddXxx()` / `app.UseXxx()` /
+  `app.MapXxx()` extension pattern visible in
+  [server/ControlPlane/Program.cs](../server/ControlPlane/Program.cs). Each
+  feature area (`AccessControl`, `Buffers`, `Codespecs`, `Compute`, `Database`,
+  `Runs`, ...) lives in its own folder under `ControlPlane/`.
+- API surface is versioned via `Tyger.ControlPlane.Versioning`; new endpoints
+  should be registered inside `app.ConfigureVersionedRouteGroup(...)` and
+  documented in OpenAPI (`server/ControlPlane/OpenApi/`). Integration tests
+  diff the generated spec against
+  [cli/integrationtest/expected_openapi_spec.yaml](../cli/integrationtest/expected_openapi_spec.yaml);
+  regenerate it when changing the public API.
+- Logging uses source-generated `LoggerExtensions` partial classes (see
+  `Buffers/LoggerExtensions.cs` etc.) — add new log entries there rather than
+  calling `_logger.LogInformation("literal")` ad hoc.
+
+### Go (CLI)
+
+- Use the existing logger: `github.com/rs/zerolog/log`. Don't add `fmt.Println`
+  for diagnostics.
+- Errors propagate via standard `error` returns; CLI top-level errors are
+  printed by cobra. Use `log.Fatal().Err(err).Msg(...)` only at the program
+  edges.
+- New `tyger` subcommands plug into [cli/internal/cmd/rootcommand.go](../cli/internal/cmd/rootcommand.go).
+  Follow the existing `NewXxxCommand() *cobra.Command` factory pattern, and use
+  `cobra.Command.SilenceUsage = true` (inherited from the common root).
+- Control-plane DTOs live in
+  [cli/internal/controlplane/model/](../cli/internal/controlplane/model/) and
+  are kept in lockstep with the server's `Tyger.ControlPlane.Model` types.
+  Update both when changing the API.
+- Integration test files **must** start with `//go:build integrationtest` and
+  declare `package integrationtest`. Use the helpers in
+  [cli/integrationtest/testutils.go](../cli/integrationtest/testutils.go)
+  (`NewTygerCmdBuilder`, `runTyger`, `runCommandSucceeds`, etc.) instead of
+  shelling out manually.
+
+### Shell scripts
+
+- All scripts begin with `#!/usr/bin/env bash` and `set -euo pipefail` (or
+  `-ecuo pipefail` for the Makefile recipes). Keep that contract.
+- Prefer the helpers in [scripts/](../scripts/) over re-implementing config
+  lookup. `scripts/get-config.sh` is the only sanctioned way to render the
+  cloud/docker/dev configuration.
+
+## Deployment model — short version
+
+- **Cloud mode** (`Makefile.cloud`): the `tyger` CLI installs cloud
+  infrastructure into Azure (`tyger cloud install`) and then the API
+  (`tyger api install`) into an AKS cluster via Helm. Container images are
+  pushed to an ACR identified by `wipContainerRegistry` in the dev config.
+  Authentication uses Microsoft Entra (cert, managed identity, or GitHub
+  federated identity, controlled by `TYGER_AUTH_METHOD`).
+- **Docker mode** (`Makefile.docker`): everything runs locally as Docker
+  containers; auth is disabled; the data plane runs alongside the control plane
+  and they talk over Unix domain sockets under [install/local/](../install/).
+- The Go installers live in
+  [cli/internal/install/cloudinstall/](../cli/internal/install/cloudinstall/) and
+  [cli/internal/install/dockerinstall/](../cli/internal/install/dockerinstall/).
+  Configuration templates they consume are in
+  [cli/internal/install/cloudinstall/](../cli/internal/install/cloudinstall/)
+  and the [deploy/helm/tyger](../deploy/helm/tyger/) chart.
+
+### Switching between cloud and docker mode
+
+The repo is intentionally checked out **once** but exposed under two paths so
+that VS Code can host a cloud window and a docker window side by side against
+the same source tree:
+
+- The devcontainer sets up a symlink `/workspaces/tyger-docker → /workspaces/tyger`
+  (see [.devcontainer/Dockerfile](../.devcontainer/Dockerfile)).
+- `make open-cloud-window` opens `code /workspaces/tyger` (cloud is the
+  default — `TYGER_ENVIRONMENT_TYPE` is unset, so the top-level Makefile
+  includes `Makefile.cloud`).
+- `make open-docker-window` opens `code /workspaces/tyger-docker`.
+  [.devcontainer/devcontainer.bashrc](../.devcontainer/devcontainer.bashrc)
+  detects that path and exports `TYGER_ENVIRONMENT_TYPE=docker` plus a
+  dedicated `TYGER_CACHE_FILE=~/.cache/tyger/.tyger-docker`. That alone is what
+  flips the Makefile to `Makefile.docker` and keeps the docker-mode `tyger
+  login` session isolated from the cloud one.
+- [.vscode/launch.json](../.vscode/launch.json) has a matching **"CLI Docker"**
+  debug configuration that points at the same cache file and uses
+  `substitutePath` to translate `/workspaces/tyger-docker` ↔
+  `/workspaces/tyger` for the debugger; use it when stepping into the CLI from
+  the docker window.
+
+Practical rules:
+
+- Always open the docker workspace via `make open-docker-window` (or
+  `code /workspaces/tyger-docker`) rather than `cd`-ing into the symlinked
+  path from a cloud terminal — otherwise `TYGER_ENVIRONMENT_TYPE` won't be
+  set and `make` will silently run the cloud recipes.
+- You can verify which mode a terminal is in with `echo $TYGER_ENVIRONMENT_TYPE`;
+  it should print `docker` in a docker window and be empty in a cloud window.
+- Don't try to "support both modes" with a manually exported env var inside a
+  cloud window. Open the dedicated window so the cache, env vars, and
+  Makefile selection all line up.
+
+## Pitfalls and house rules
+
+- **Don't break the lockfiles.** After bumping NuGet or Go modules, regenerate
+  both the manifest and the lockfile and commit them together.
+- **Don't bypass the Makefile.** CI invokes the same targets you do; reproducing
+  a CI failure usually means running the exact `make ...` target locally with
+  the same `TYGER_ENVIRONMENT_TYPE`.
+- **Don't add API fields without versioning.** The server uses
+  `Tyger.ControlPlane.Versioning` and the CLI keeps a default version constant
+  (`controlplane.DefaultApiVersion`). Add new fields behind a new minor version
+  and update the OpenAPI snapshot test.
+- **Don't manually edit `server/ControlPlane/appsettings.local.json`.** It is
+  regenerated by `make set-localsettings` from live Helm values; persistent
+  changes belong in `appsettings.json` or the chart.
+- **Don't disable analyzers or warnings as a quick fix.** The build treats
+  warnings as errors on purpose; fix the underlying issue or scope a targeted
+  suppression with a justifying comment.
+- **Don't generate or commit secrets.** Test client certs come from Key Vault
+  via `make download-test-client-cert`; never hard-code credentials or PII.
+- **Don't run destructive `make` targets without confirming**: `down`,
+  `remove-environment`, `purge-runs`, and `publish-official-images` all touch
+  shared infrastructure.
+
+## Quick start checklist for an edit
+
+1. Identify the area: server (C#) or CLI/installer (Go).
+2. Read the existing file and its siblings in the same folder; mimic the
+   patterns (extension methods, naming, logging).
+3. Make the change with the minimal diff.
+4. Run `make build` and the relevant test target (`make unit-test` is usually
+   enough; run `make integration-test-no-up-fast-only` if you touched the API
+   contract or CLI commands).
+5. Run `make verify-format` before declaring done.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,9 +2,9 @@
 
 Tyger is a REST API and CLI for **remote signal processing**. It accepts streaming
 input, runs containerized user code on Kubernetes (cloud) or Docker (local), and
-exposes the results via WORM data streams ("buffers"). It is deployed as two
-ASP.NET Core services (a control plane and a data plane) plus a set of Go-based
-CLIs and sidecars.
+exposes the results via WORM data streams ("buffers"). It is deployed an
+ASP.NET Core control-plane service (and a data plane service in local mode) plus
+a set of Go-based CLIs and sidecars.
 
 Always read the surrounding code before changing it, and prefer minimal,
 targeted edits that match the conventions described below.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -143,7 +143,7 @@ devcontainer's `gopls` is already configured with this tag.
 #### Data plane
 
 - [server/DataPlane/](../server/DataPlane/) is its own minimal ASP.NET Core
-  service (`tyger-data-plane`) that handles raw buffer I/O in docker mode. It
+  service (`tyger-data-plane`) that handles buffer storage in Docker mode. It
   shares `Tyger.Common` with the control plane and follows the same
   `builder.AddXxx()` / `app.UseXxx()` wiring (see
   [server/DataPlane/Program.cs](../server/DataPlane/Program.cs)), including its

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,8 @@ devcontainer's `gopls` is already configured with this tag.
   `tyger ...` against it. For very fast inner iteration you can instead run
   the control plane locally with `make set-localsettings && make run` and
   point `tyger login` at `http://localhost:5000` (cloud) or the local Unix
-  socket (docker).
+  socket (docker). In cloud mode `make login-local` does this for you; in
+  docker mode use `make login`.
 - **Changing the API contract** (anything that touches DTOs, route handlers,
   or the OpenAPI surface): update both the C# model in
   `server/ControlPlane/Model/` and the Go model in
@@ -139,6 +140,37 @@ devcontainer's `gopls` is already configured with this tag.
   `Buffers/LoggerExtensions.cs` etc.) — add new log entries there rather than
   calling `_logger.LogInformation("literal")` ad hoc.
 
+#### Data plane
+
+- [server/DataPlane/](../server/DataPlane/) is its own minimal ASP.NET Core
+  service (`tyger-data-plane`) that handles raw buffer I/O in docker mode. It
+  shares `Tyger.Common` with the control plane and follows the same
+  `builder.AddXxx()` / `app.UseXxx()` wiring (see
+  [server/DataPlane/Program.cs](../server/DataPlane/Program.cs)), including its
+  own `ConfigureVersionedRouteGroup` and `Tyger.DataPlane.Versioning`. It binds
+  to a Unix domain socket and is configured by `make set-data-plane-localsettings`
+  / run with `make run-data-plane`. Keep its surface small — buffer storage
+  logic lives in `DataPlaneStorageHandler.cs`.
+
+#### Database and migrations
+
+- Database access lives in [server/ControlPlane/Database/](../server/ControlPlane/Database/)
+  (`Repository.cs`, `Database.cs`). Schema changes are versioned, ordered
+  migrations under
+  [server/ControlPlane/Database/Migrations/](../server/ControlPlane/Database/Migrations/)
+  (`1.cs`, `2.cs`, ...). To add one: create the next `MigratorN` class
+  (subclass `Migrator`, implement `Apply`), then register it as a new entry in
+  the `DatabaseVersion` enum in `Migrations/DatabaseVersions.cs` with
+  `[Migrator(typeof(MigratorN))]` and a `[Description(...)]`.
+- Migrations are designed to run **without downtime** (additive, idempotent
+  SQL — e.g. `ADD COLUMN IF NOT EXISTS`); see
+  [docs/reference/database-management.md](../docs/reference/database-management.md).
+  They are applied via `tyger api migrations apply` (`make up` runs this in
+  cloud mode) and listed with `tyger api migrations list`. The
+  [cli/integrationtest/migrations_test.go](../cli/integrationtest/migrations_test.go)
+  end-to-end test exercises this path, so run
+  `make integration-test-no-up-fast-only` after touching migrations.
+
 ### Go (CLI)
 
 - Use the existing logger: `github.com/rs/zerolog/log`. Don't add `fmt.Println`
@@ -159,13 +191,50 @@ devcontainer's `gopls` is already configured with this tag.
   (`NewTygerCmdBuilder`, `runTyger`, `runCommandSucceeds`, etc.) instead of
   shelling out manually.
 
+#### HTTP client transport (tread carefully)
+
+The CLI talks to a Tyger endpoint over several connection types, all built in
+[cli/internal/client/](../cli/internal/client/). This is one of the subtler
+areas — understand the layering before changing it:
+
+- `client.NewClient` (in [client.go](../cli/internal/client/client.go)) wraps a
+  base `*http.Transport` in a stack of `http.RoundTripper`s (clock-skew check,
+  optional debug logging) on top of a `retryablehttp.Client`. Layers are
+  injected via `ClientOptions.CreateTransport` (`MakeRoundTripper`) and
+  `CreateDialer` (`MakeDialer`) rather than by rewriting `NewClient`. Use
+  `NewControlPlaneClient` / `NewDataPlaneClient` (the latter sets a longer
+  timeout) instead of calling `NewClient` directly.
+- The connection type is driven by the login URL scheme, surfaced by
+  `TygerClient.ConnectionType()`: `http`/`https` (TCP), `http+unix` (Unix
+  domain socket), `ssh`, and `docker`.
+- **Unix sockets:** requests use the `http+unix` scheme with the socket path
+  base32-encoded into the host (prefix `unix----`); `makeUnixDialer` /
+  `unixAwareTransport` ([unixtransport.go](../cli/internal/client/unixtransport.go))
+  decode it back to a `unix` dial. Don't put raw filesystem paths in the URL
+  host.
+- **SSH and Docker tunnels** are implemented as a `CommandTransport`
+  ([commandtransport.go](../cli/internal/client/commandtransport.go)) that
+  shells out to `ssh` / `docker`, writing the HTTP request to the process's
+  stdin and reading the response from stdout. It only intercepts `http+unix`
+  requests and otherwise delegates to `next`. URL parsing/formatting for these
+  lives in [sshurl.go](../cli/internal/client/sshurl.go) and
+  [dockerurl.go](../cli/internal/client/dockerurl.go); the transport is wired
+  up in [cli/internal/controlplane/login.go](../cli/internal/controlplane/login.go).
+- **Proxies:** `ParseProxy` accepts `none`, `auto`/`automatic`/`""`, or an
+  explicit URL, and `httpCheckProxyFunc` deliberately bypasses proxies for
+  plaintext `http` (the `tyger` → `tyger-proxy` path) unless it's a Unix socket.
+- **Redaction:** never log raw URLs or HTTP errors — use `RedactUrl` /
+  `RedactHttpError`, which strip query-string values (preserving only
+  non-sensitive keys like `api-version`).
+
 ### Shell scripts
 
 - All scripts begin with `#!/usr/bin/env bash` and `set -euo pipefail` (or
   `-ecuo pipefail` for the Makefile recipes). Keep that contract.
 - Prefer the helpers in [scripts/](../scripts/) over re-implementing config
-  lookup. `scripts/get-config.sh` is the only sanctioned way to render the
-  cloud/docker/dev configuration.
+  lookup. Use `make get-config` to render the cloud/docker/dev configuration;
+  fall back to `scripts/get-config.sh` directly only when you need its special
+  options.
 
 ## Deployment model — short version
 
@@ -232,8 +301,9 @@ Practical rules:
   (`controlplane.DefaultApiVersion`). Add new fields behind a new minor version
   and update the OpenAPI snapshot test.
 - **Don't manually edit `server/ControlPlane/appsettings.local.json`.** It is
-  regenerated by `make set-localsettings` from live Helm values; persistent
-  changes belong in `appsettings.json` or the chart.
+  regenerated by `make set-localsettings` (in cloud mode from live Helm values,
+  in docker mode from the rendered config); persistent changes belong in
+  `appsettings.json` or the chart.
 - **Don't disable analyzers or warnings as a quick fix.** The build treats
   warnings as errors on purpose; fix the underlying issue or scope a targeted
   suppression with a justifying comment.

--- a/Makefile.cloud
+++ b/Makefile.cloud
@@ -187,6 +187,8 @@ _get-login-spec:
 	elif [[ "${TYGER_AUTH_METHOD}" == "github" ]]; then
 		auth_parameters="github: true
 		targetFederatedIdentity: '$${client_uri}'"
+	elif [[ "${TYGER_AUTH_METHOD}" == "az" ]]; then
+		auth_parameters="azureCli: true"
 	else
 		echo "Unknown authentication method: ${TYGER_AUTH_METHOD}"
 		exit 1
@@ -251,6 +253,8 @@ get-proxy-config:
 	elif [[ "${TYGER_AUTH_METHOD}" == "github" ]]; then
 		auth_parameters="github: true
 		targetFederatedIdentity: '$${client_uri}'"
+	elif [[ "${TYGER_AUTH_METHOD}" == "az" ]]; then
+		auth_parameters="azureCli: true"
 	else
 		echo "Unknown authentication method: ${TYGER_AUTH_METHOD}"
 		exit 1

--- a/cli/cmd/tyger-proxy/main.go
+++ b/cli/cmd/tyger-proxy/main.go
@@ -146,6 +146,9 @@ func readProxyOptions(optionsFilePath string, options *tygerproxy.ProxyOptions) 
 		if options.GitHub {
 			return errors.New("github cannot be specified when using SSH or Unix socket connection")
 		}
+		if options.AzureCli {
+			return errors.New("azureCli cannot be specified when using SSH or Unix socket connection")
+		}
 		if options.ServicePrincipal != "" {
 			return errors.New("servicePrincipal cannot be specified when using SSH or Unix socket connection")
 		}
@@ -169,6 +172,9 @@ func readProxyOptions(optionsFilePath string, options *tygerproxy.ProxyOptions) 
 			if options.CertificateThumbprint != "" {
 				return errors.New("certificateThumbprint cannot be specified when using managed identity")
 			}
+			if options.AzureCli {
+				return errors.New("azureCli cannot be specified when using managed identity")
+			}
 		} else if options.GitHub {
 			if options.ServicePrincipal != "" {
 				return errors.New("servicePrincipal cannot be specified when using GitHub authentication")
@@ -179,9 +185,25 @@ func readProxyOptions(optionsFilePath string, options *tygerproxy.ProxyOptions) 
 			if options.CertificateThumbprint != "" {
 				return errors.New("certificateThumbprint cannot be specified when using GitHub authentication")
 			}
+			if options.AzureCli {
+				return errors.New("azureCli cannot be specified when using GitHub authentication")
+			}
+		} else if options.AzureCli {
+			if options.ServicePrincipal != "" {
+				return errors.New("servicePrincipal cannot be specified when using azureCli")
+			}
+			if options.CertificatePath != "" {
+				return errors.New("certificatePath cannot be specified when using azureCli")
+			}
+			if options.CertificateThumbprint != "" {
+				return errors.New("certificateThumbprint cannot be specified when using azureCli")
+			}
+			if options.TargetFederatedIdentity != "" {
+				return errors.New("targetFederatedIdentity cannot be specified when using azureCli")
+			}
 		} else {
 			if options.ServicePrincipal == "" {
-				return errors.New("if both managedIdentity and github are both not true, servicePrincipal must be specified in the options file")
+				return errors.New("one of managedIdentity, github, azureCli, or servicePrincipal must be specified in the options file")
 			}
 
 			if runtime.GOOS == "windows" {

--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -3028,11 +3028,10 @@ func TestForbiddenOperationsWithContributorRole(t *testing.T) {
 func TestLoginWithAzureCliErrors(t *testing.T) {
 	t.Parallel()
 
+	skipIfUsingUnixSocket(t)
+
 	c, err := controlplane.GetClientFromCache()
 	require.NoError(t, err)
-	if c.RawControlPlaneUrl == nil || c.RawControlPlaneUrl.Scheme != "https" {
-		t.Skip("Skipping test because the control plane is not a cloud (https) deployment")
-	}
 
 	config := getCloudConfig(t)
 	var legacyDomain, legacyTenant string

--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -3019,6 +3019,109 @@ func TestForbiddenOperationsWithContributorRole(t *testing.T) {
 	require.Contains(t, stdErr, "Forbidden")
 }
 
+// TestLoginWithAzureCliErrors exercises the error paths of `tyger login --az`.
+// It only runs against cloud (https) deployments, and only when the current
+// deployment is not the legacy organization (the legacy org is used as the
+// target for the failing login attempts). The legacy org lives in a different
+// tenant than the one the test client is signed in to and does not pre-authorize
+// the Azure CLI, which makes it a convenient target for these negative cases.
+func TestLoginWithAzureCliErrors(t *testing.T) {
+	t.Parallel()
+
+	c, err := controlplane.GetClientFromCache()
+	require.NoError(t, err)
+	if c.RawControlPlaneUrl == nil || c.RawControlPlaneUrl.Scheme != "https" {
+		t.Skip("Skipping test because the control plane is not a cloud (https) deployment")
+	}
+
+	config := getCloudConfig(t)
+	var legacyDomain, legacyTenant string
+	for _, org := range config.Organizations {
+		if org.Name == "legacy" {
+			if org.Api != nil {
+				legacyDomain = org.Api.DomainName
+				if org.Api.AccessControl != nil {
+					legacyTenant = org.Api.AccessControl.TenantID
+				}
+			}
+			break
+		}
+	}
+	if legacyDomain == "" {
+		t.Skip("Skipping test because the legacy organization is not configured")
+	}
+	if strings.EqualFold(c.RawControlPlaneUrl.Host, legacyDomain) {
+		t.Skip("Skipping test because the current deployment targets the legacy organization")
+	}
+
+	legacyUrl := "https://" + legacyDomain
+
+	t.Run("AzureCliNotInstalled", func(t *testing.T) {
+		// Hide `az` from the tyger process by pointing PATH at an empty
+		// directory so the Azure CLI cannot be found.
+		tempCache := filepath.Join(t.TempDir(), "cache")
+		_, stdErr, err := newTygerCmdWithModifiedEnv(
+			map[string]string{
+				"TYGER_CACHE_FILE": tempCache,
+				"PATH":             t.TempDir(),
+			},
+			"login", legacyUrl, "--az",
+		).Run()
+
+		require.Error(t, err)
+		require.Contains(t, stdErr, "aka.ms/azure-cli")
+	})
+
+	t.Run("WrongTenant", func(t *testing.T) {
+		if _, lookErr := exec.LookPath("az"); lookErr != nil {
+			t.Skip("Skipping because the Azure CLI is not installed")
+		}
+
+		// The wrong-tenant error only occurs when `az` is signed in to a tenant
+		// other than the legacy organization's tenant.
+		tenantOut, _, accountErr := runCommand("az", "account", "show", "--query", "tenantId", "-o", "tsv")
+		if accountErr != nil {
+			t.Skip("Skipping because the Azure CLI is not signed in")
+		}
+		if legacyTenant != "" && strings.EqualFold(strings.TrimSpace(tenantOut), legacyTenant) {
+			t.Skip("Skipping because the Azure CLI is signed in to the legacy organization's tenant")
+		}
+
+		tempCache := filepath.Join(t.TempDir(), "cache")
+		_, stdErr, err := newTygerCmdWithModifiedEnv(
+			map[string]string{"TYGER_CACHE_FILE": tempCache},
+			"login", legacyUrl, "--az",
+		).Run()
+
+		require.Error(t, err)
+		require.Contains(t, stdErr, "different tenant")
+		if legacyTenant != "" {
+			require.Contains(t, stdErr, legacyTenant)
+		}
+	})
+}
+
+// newTygerCmdWithModifiedEnv builds a tyger command whose environment is a copy
+// of the current process environment with the given overrides applied.
+func newTygerCmdWithModifiedEnv(overrides map[string]string, args ...string) *CmdBuilder {
+	b := NewTygerCmdBuilder(args...)
+	applied := make(map[string]bool, len(overrides))
+	for _, entry := range os.Environ() {
+		key, value, _ := strings.Cut(entry, "=")
+		if override, ok := overrides[key]; ok {
+			value = override
+			applied[key] = true
+		}
+		b.Env(key, value)
+	}
+	for key, value := range overrides {
+		if !applied[key] {
+			b.Env(key, value)
+		}
+	}
+	return b
+}
+
 func waitForRunStarted(t *testing.T, runId string) model.Run {
 	t.Helper()
 	return waitForRun(t, runId, true, false)

--- a/cli/integrationtest/controlplane_test.go
+++ b/cli/integrationtest/controlplane_test.go
@@ -3060,6 +3060,7 @@ func TestLoginWithAzureCliErrors(t *testing.T) {
 		// directory so the Azure CLI cannot be found.
 		tempCache := filepath.Join(t.TempDir(), "cache")
 		_, stdErr, err := newTygerCmdWithModifiedEnv(
+			t,
 			map[string]string{
 				"TYGER_CACHE_FILE": tempCache,
 				"PATH":             t.TempDir(),
@@ -3088,6 +3089,7 @@ func TestLoginWithAzureCliErrors(t *testing.T) {
 
 		tempCache := filepath.Join(t.TempDir(), "cache")
 		_, stdErr, err := newTygerCmdWithModifiedEnv(
+			t,
 			map[string]string{"TYGER_CACHE_FILE": tempCache},
 			"login", legacyUrl, "--az",
 		).Run()
@@ -3102,8 +3104,16 @@ func TestLoginWithAzureCliErrors(t *testing.T) {
 
 // newTygerCmdWithModifiedEnv builds a tyger command whose environment is a copy
 // of the current process environment with the given overrides applied.
-func newTygerCmdWithModifiedEnv(overrides map[string]string, args ...string) *CmdBuilder {
-	b := NewTygerCmdBuilder(args...)
+//
+// The `tyger` binary is resolved to an absolute path against the current
+// process's PATH before the overrides are applied, so callers can safely
+// override PATH (for example, to hide `az` from the child process) without also
+// hiding `tyger` itself.
+func newTygerCmdWithModifiedEnv(t *testing.T, overrides map[string]string, args ...string) *CmdBuilder {
+	tygerPath, err := exec.LookPath("tyger")
+	require.NoError(t, err, "unable to resolve the tyger executable on PATH")
+
+	b := NewCmdBuilder(tygerPath, args...)
 	applied := make(map[string]bool, len(overrides))
 	for _, entry := range os.Environ() {
 		key, value, _ := strings.Cut(entry, "=")

--- a/cli/internal/cmd/login.go
+++ b/cli/internal/cmd/login.go
@@ -31,7 +31,7 @@ func NewLoginCommand() *cobra.Command {
 	local := false
 
 	loginCmd := &cobra.Command{
-		Use:   "login { SERVER_URL [--service-principal APPID --certificate CERTPATH] [--use-device-code] [--identity [--identity-client-id [CLIENT_ID]] --federated-identity CLIENT_ID] [--proxy PROXY] } | --file LOGIN_FILE.yaml | --local",
+		Use:   "login { SERVER_URL [--service-principal APPID --certificate CERTPATH] [--use-device-code] [--identity [--identity-client-id [CLIENT_ID]] --federated-identity CLIENT_ID] [--az] [--proxy PROXY] } | --file LOGIN_FILE.yaml | --local",
 		Short: "Login to a server",
 		Long: `Login to the Tyger server at the given URL.
 Subsequent commands will be performed against this server.`,
@@ -117,6 +117,10 @@ Subsequent commands will be performed against this server.`,
 					if options.TargetFederatedIdentity != "" {
 						return errors.New("targetFederatedIdentity can only be set when managedIdentity or github is used")
 					}
+
+					if options.AzureCli {
+						return errors.New("azureCli cannot be used when servicePrincipal is set")
+					}
 				} else if options.ManagedIdentity {
 					if options.UseDeviceCode {
 						return errors.New("useDeviceCode cannot be used when managedIdentity is set")
@@ -128,6 +132,10 @@ Subsequent commands will be performed against this server.`,
 
 					if options.CertificateThumbprint != "" {
 						return errors.New("certificateThumbprint cannot be set when managedIdentity is used")
+					}
+
+					if options.AzureCli {
+						return errors.New("azureCli cannot be used when managedIdentity is set")
 					}
 				} else if options.GitHub {
 					if options.TargetFederatedIdentity == "" {
@@ -144,6 +152,26 @@ Subsequent commands will be performed against this server.`,
 
 					if options.CertificateThumbprint != "" {
 						return errors.New("certificateThumbprint cannot be set when github is used")
+					}
+
+					if options.AzureCli {
+						return errors.New("azureCli cannot be used when github is set")
+					}
+				} else if options.AzureCli {
+					if options.UseDeviceCode {
+						return errors.New("useDeviceCode cannot be used when azureCli is set")
+					}
+
+					if options.CertificatePath != "" || options.CertificateThumbprint != "" {
+						return errors.New("certificatePath and certificateThumbprint cannot be set when azureCli is used")
+					}
+
+					if options.ManagedIdentityClientId != "" {
+						return errors.New("managedIdentityClientId can only be set when managedIdentity is used")
+					}
+
+					if options.TargetFederatedIdentity != "" {
+						return errors.New("targetFederatedIdentity can only be set when managedIdentity or github is used")
 					}
 				} else {
 					if options.CertificatePath != "" {
@@ -195,6 +223,9 @@ Subsequent commands will be performed against this server.`,
 					if options.TargetFederatedIdentity != "" {
 						return errors.New("--federated-identity can only be used with --identity or --github")
 					}
+					if options.AzureCli {
+						return errors.New("--az cannot be used with --service-principal")
+					}
 				} else if options.ManagedIdentity {
 					if options.UseDeviceCode {
 						return errors.New("--use-device-code cannot be used with --identity")
@@ -207,6 +238,9 @@ Subsequent commands will be performed against this server.`,
 					}
 					if options.CertificateThumbprint != "" {
 						return errors.New("--cert-thumbprint can only be used with --service-principal")
+					}
+					if options.AzureCli {
+						return errors.New("--az cannot be used with --identity")
 					}
 				} else if options.GitHub {
 					if options.TargetFederatedIdentity == "" {
@@ -223,6 +257,22 @@ Subsequent commands will be performed against this server.`,
 					}
 					if options.CertificateThumbprint != "" {
 						return errors.New("--cert-thumbprint can only be used with --service-principal")
+					}
+					if options.AzureCli {
+						return errors.New("--az cannot be used with --github")
+					}
+				} else if options.AzureCli {
+					if options.UseDeviceCode {
+						return errors.New("--use-device-code cannot be used with --az")
+					}
+					if options.CertificatePath != "" || options.CertificateThumbprint != "" {
+						return errors.New("--cert-file and --cert-thumbprint cannot be used with --az")
+					}
+					if options.ManagedIdentityClientId != "" {
+						return errors.New("--identity-client-id can only be used with --identity")
+					}
+					if options.TargetFederatedIdentity != "" {
+						return errors.New("--federated-identity can only be used with --identity or --github")
 					}
 				} else {
 					if options.CertificatePath != "" {
@@ -273,6 +323,12 @@ managedIdentityClientId: # Optionally specify the client ID of the managed ident
 # Whether to use GitHub Actions tokens with federated identity for authentication.
 github: false
 
+# Whether to use the Azure CLI ('az') to acquire access tokens.
+# Requires that the Azure CLI is installed, that you are signed in with 'az login' to the
+# same tenant as the Tyger server, and that the operator has set 'enableAzureCliLogin: true'
+# in the Tyger access control config.
+azureCli: false
+
 # If using managed identity or GitHub Actions, specify the client ID of the federated identity to authenticate as.
 targetFederatedIdentity: # Optionally specify a federated identity to authenticate as using the managed identity.
 
@@ -303,6 +359,8 @@ tlsCaCertificates:
 	loginCmd.Flags().StringVar(&options.ManagedIdentityClientId, "identity-client-id", "", "The client ID of the managed identity to use. If not specified, the system-assigned identity is used, or if not present, the single user-assigned identity.")
 
 	loginCmd.Flags().BoolVar(&options.GitHub, "github", false, "Use GitHub Actions tokens with federated identity for authentication. Requires --federated-identity to be set.")
+
+	loginCmd.Flags().BoolVar(&options.AzureCli, "az", false, "Use the Azure CLI ('az') to acquire access tokens. Requires 'az login' in the same tenant as the Tyger server and 'enableAzureCliLogin: true' in the access control config.")
 
 	loginCmd.Flags().StringVar(&options.TargetFederatedIdentity, "federated-identity", "", "Use federation to authenticate as this identity. Can only be used with --managed-identity or --github.")
 

--- a/cli/internal/controlplane/login.go
+++ b/cli/internal/controlplane/login.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -54,6 +55,7 @@ type LoginConfig struct {
 	ManagedIdentity         bool                          `json:"managedIdentity,omitempty"`
 	ManagedIdentityClientId string                        `json:"managedIdentityClientId,omitempty"`
 	GitHub                  bool                          `json:"github,omitempty"`
+	AzureCli                bool                          `json:"azureCli,omitempty"`
 	TargetFederatedIdentity string                        `json:"targetFederatedIdentity,omitempty"`
 	Proxy                   string                        `json:"proxy,omitempty"`
 	TlsCaCertificates       client.TlsCaCertificateSource `json:"tlsCaCertificates,omitempty"`
@@ -105,6 +107,7 @@ type serviceInfo struct {
 	ManagedIdentity         bool   `json:"managedIdentity,omitempty"`
 	ManagedIdentityClientId string `json:"managedIdentityClientId,omitempty"`
 	GitHub                  bool   `json:"github,omitempty"`
+	AzureCli                bool   `json:"azureCli,omitempty"`
 	TargetFederatedIdentity string `json:"targetFederatedIdentity,omitempty"`
 	CertPath                string `json:"certPath,omitempty"`
 	CertThumbprint          string `json:"certThumbprint,omitempty"`
@@ -178,6 +181,7 @@ func Login(ctx context.Context, options LoginConfig) (*client.TygerClient, *mode
 		CertThumbprint:          options.CertificateThumbprint,
 		ManagedIdentity:         options.ManagedIdentity,
 		ManagedIdentityClientId: options.ManagedIdentityClientId,
+		AzureCli:                options.AzureCli,
 		TargetFederatedIdentity: options.TargetFederatedIdentity,
 		Proxy:                   options.Proxy,
 		TlsCaCertificates:       options.TlsCaCertificates,
@@ -352,6 +356,8 @@ func Login(ctx context.Context, options LoginConfig) (*client.TygerClient, *mode
 				authResult, si.Principal, err = si.performManagedIdentityLogin(ctx, options.ManagedIdentityClientId, options.TargetFederatedIdentity)
 			} else if options.GitHub {
 				authResult, si.Principal, err = si.performGitHubLogin(ctx, options.TargetFederatedIdentity)
+			} else if options.AzureCli {
+				authResult, si.Principal, err = si.performAzureCliLogin(ctx)
 			} else {
 				authResult, si.Principal, err = si.performUserLogin(ctx, options.UseDeviceCode)
 				if si.ClientId == "" {
@@ -506,6 +512,12 @@ func (c *serviceInfo) GetAccessToken(ctx context.Context) (string, error) {
 	} else if c.GitHub {
 		var err error
 		accessToken, _, err = c.performGitHubLogin(ctx, c.TargetFederatedIdentity)
+		if err != nil {
+			return "", err
+		}
+	} else if c.AzureCli {
+		var err error
+		accessToken, _, err = c.performAzureCliLogin(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -956,6 +968,127 @@ func (si *serviceInfo) performGitHubLogin(ctx context.Context, targetFederatedId
 	}
 
 	return si.performFederatedIdentityLogin(ctx, response.Value, targetFederatedIdentity)
+}
+
+// performAzureCliLogin acquires an access token for the Tyger API by shelling
+// out to the Azure CLI (`az`). The Azure CLI's Entra application must be added
+// as a pre-authorized application on the Tyger API app (see
+// `enableAzureCliLogin` in the access control config) for this to succeed
+// without an interactive consent prompt.
+func (si *serviceInfo) performAzureCliLogin(ctx context.Context) (AccessToken, string, error) {
+	tenantId, err := tenantIdFromAuthority(si.Authority)
+	if err != nil {
+		return AccessToken{}, "", err
+	}
+
+	cred, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{TenantID: tenantId})
+	if err != nil {
+		return AccessToken{}, "", translateAzureCliCredentialError(err, tenantId)
+	}
+
+	scope := fmt.Sprintf("%s/%s", si.Audience, servicePrincipalScope)
+	tok, err := cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{scope}, TenantID: tenantId})
+	if err != nil {
+		return AccessToken{}, "", translateAzureCliCredentialError(err, tenantId)
+	}
+
+	var principal string
+	claims := jwt.MapClaims{}
+	if _, _, parseErr := jwt.NewParser().ParseUnverified(tok.Token, claims); parseErr == nil {
+		// The Tyger API app may be configured to issue either v1.0 or v2.0 tokens,
+		// and the token may represent a user or an application (service principal /
+		// managed identity). Check the relevant claims for each combination, falling
+		// back to the object ID (always present) as a last resort:
+		//   - user:        preferred_username (v2) or upn (v1)
+		//   - application:  azp (v2) or appid (v1)
+		//   - fallback:     oid (object ID, present in both v1 and v2 tokens)
+		for _, claimName := range []string{"preferred_username", "upn", "azp", "appid", "oid"} {
+			if value, ok := claims[claimName].(string); ok && value != "" {
+				principal = value
+				break
+			}
+		}
+	}
+
+	return AccessToken(tok), principal, nil
+}
+
+// tenantIdFromAuthority extracts the tenant ID (the last non-empty path
+// segment) from an authority URL like "https://login.microsoftonline.com/<tenantId>".
+func tenantIdFromAuthority(authority string) (string, error) {
+	parsed, err := url.Parse(authority)
+	if err != nil {
+		return "", fmt.Errorf("invalid authority %q: %w", authority, err)
+	}
+
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	for i := len(segments) - 1; i >= 0; i-- {
+		if segments[i] != "" {
+			return segments[i], nil
+		}
+	}
+	return "", fmt.Errorf("could not determine tenant ID from authority %q", authority)
+}
+
+// translateAzureCliCredentialError converts the opaque errors returned by the
+// Azure CLI credential into actionable guidance for the `--az` login flow.
+//
+// The azidentity SDK does not expose typed errors or error codes for the Azure
+// CLI credential: every failure is wrapped in an unexported
+// credentialUnavailableError whose message is the raw stderr from
+// `az account get-access-token`. The SDK explicitly documents that these error
+// message contents are "not contractual and can change over time", so the only
+// signals worth matching on are:
+//   - AADSTS error codes, which are stable, non-localized identifiers embedded
+//     in the underlying Microsoft Entra error text.
+//   - The SDK-normalized "Azure CLI not found on path" message, which it emits
+//     for a missing `az` binary (CLI exit code 127 / "'az' is not recognized").
+//
+// Anything we can't confidently classify falls through to a generic message
+// that wraps the original error so the raw `az` output remains visible.
+func translateAzureCliCredentialError(err error, tenantId string) error {
+	if err == nil {
+		return nil
+	}
+
+	lower := strings.ToLower(err.Error())
+	containsAny := func(substrings ...string) bool {
+		for _, s := range substrings {
+			// Match around word boundaries so that, for example, "aadsts50020"
+			// does not also match "aadsts500201".
+			pattern := `(?:^|\W)` + regexp.QuoteMeta(s) + `(?:$|\W)`
+			if matched, _ := regexp.MatchString(pattern, lower); matched {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch {
+	// The `az` binary is missing. The SDK normalizes this (CLI exit code 127 or
+	// the Windows "'az' is not recognized" prefix) to "Azure CLI not found on path".
+	case containsAny("azure cli not found", "'az' is not recognized"):
+		return fmt.Errorf("the Azure CLI (`az`) was not found on PATH. Install it from https://aka.ms/azure-cli and run `az login` before retrying: %w", err)
+
+	// Consent has not been granted to the Azure CLI app for the Tyger API. When the
+	// Azure CLI app is pre-authorized this prompt is bypassed, so AADSTS65001 is the
+	// signal that pre-authorization is missing.
+	case containsAny("aadsts65001"):
+		return fmt.Errorf("the Azure CLI is not pre-authorized to access the Tyger API. Ask an administrator to set `enableAzureCliLogin: true` in the access control config and run `tyger access-control apply`: %w", err)
+
+	// The signed-in identity belongs to / can only access a different tenant than
+	// the one that owns the Tyger API (AADSTS50020: user from another tenant,
+	// AADSTS500011: resource principal not found in tenant).
+	case containsAny("aadsts50020", "aadsts500011", "aadsts90072"):
+		return fmt.Errorf("the Azure CLI is signed in to a different tenant than the Tyger server. Run `az login --tenant %s` against the Tyger tenant and retry: %w", tenantId, err)
+
+	// `az` fails locally (before reaching Microsoft Entra) when it isn't signed in,
+	// so there is no AADSTS code to match; fall back to the CLI's own prompt text.
+	case containsAny("az login"):
+		return fmt.Errorf("the Azure CLI is not signed in. Run `az login --tenant %s` before retrying: %w", tenantId, err)
+	}
+
+	return fmt.Errorf("failed to acquire an access token via the Azure CLI: %w", err)
 }
 
 func (si *serviceInfo) performFederatedIdentityLogin(ctx context.Context, token string, targetFederatedIdentity string) (AccessToken, string, error) {

--- a/cli/internal/controlplane/login.go
+++ b/cli/internal/controlplane/login.go
@@ -1082,6 +1082,16 @@ func translateAzureCliCredentialError(err error, tenantId string) error {
 	case containsAny("aadsts50020", "aadsts500011", "aadsts90072"):
 		return fmt.Errorf("the Azure CLI is signed in to a different tenant than the Tyger server. Run `az login --tenant %s` against the Tyger tenant and retry: %w", tenantId, err)
 
+	// In Azure Cloud Shell the Azure CLI does not use a normal interactive /
+	// refresh-token flow. It acquires tokens through an MSI-style token endpoint
+	// (the "Cloud Shell credential") that acts on behalf of the signed-in user
+	// but can only issue tokens for a curated allow-list of audiences (ARM,
+	// Graph, Key Vault, ...). Custom application audiences like the Tyger API are
+	// rejected with "not a supported MSI token audience", and there is no way to
+	// make the Cloud Shell credential issue a token for the Tyger API.
+	case containsAny("not a supported msi token audience"):
+		return fmt.Errorf("the Azure CLI in this environment (for example, Azure Cloud Shell) acquires tokens through a credential that only supports a fixed set of audiences and cannot issue tokens for the Tyger API: %w", err)
+
 	// `az` fails locally (before reaching Microsoft Entra) when it isn't signed in,
 	// so there is no AADSTS code to match; fall back to the CLI's own prompt text.
 	case containsAny("az login"):

--- a/cli/internal/controlplane/login.go
+++ b/cli/internal/controlplane/login.go
@@ -1077,9 +1077,8 @@ func translateAzureCliCredentialError(err error, tenantId string) error {
 		return fmt.Errorf("the Azure CLI is not pre-authorized to access the Tyger API. Ask an administrator to set `enableAzureCliLogin: true` in the access control config and run `tyger access-control apply`: %w", err)
 
 	// The signed-in identity belongs to / can only access a different tenant than
-	// the one that owns the Tyger API (AADSTS50020: user from another tenant,
-	// AADSTS500011: resource principal not found in tenant).
-	case containsAny("aadsts50020", "aadsts500011", "aadsts90072"):
+	// the one that owns the Tyger API
+	case containsAny("aadsts50020", "aadsts500011", "aadsts90072", "aadsts700016"):
 		return fmt.Errorf("the Azure CLI is signed in to a different tenant than the Tyger server. Run `az login --tenant %s` against the Tyger tenant and retry: %w", tenantId, err)
 
 	// In Azure Cloud Shell the Azure CLI does not use a normal interactive /

--- a/cli/internal/install/cloudinstall/access-control-pretty.tpl
+++ b/cli/internal/install/cloudinstall/access-control-pretty.tpl
@@ -13,6 +13,11 @@ cliAppId: {{ if .CliAppId -}} {{ .CliAppId }} {{- else -}} "" # `tyger access-co
 serviceManagementReference: {{ .ServiceManagementReference }}
 {{- end }}
 
+# Pre-authorizes the Azure CLI Entra application so that users who are
+# signed in with `az login` can authenticate to Tyger using `tyger login --az`.
+# Users still need to be granted a role below in order to access Tyger.
+enableAzureCliLogin: {{ .EnableAzureCliLogin }}
+
 # Principals in role assignments are specified in the following ways:
 #
 # For users, specify the object ID and/or the user principal name.

--- a/cli/internal/install/cloudinstall/accesscontrol.go
+++ b/cli/internal/install/cloudinstall/accesscontrol.go
@@ -25,6 +25,12 @@ const permissionScopeValue = "Read.Write"
 const tygerOwnerRoleValue = "owner"
 const tygerContributorRoleValue = "contributor"
 
+// The well-known Entra application ID of the Azure CLI (`az`).
+// Pre-authorizing this app on the Tyger API allows users who are signed in
+// with `az login` to acquire a token for Tyger via
+// `az account get-access-token --resource <apiAppUri>`.
+const azureCliAppId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+
 //go:embed access-control-pretty.tpl
 var prettyPrintRbacTemplate string
 
@@ -84,7 +90,7 @@ func ApplyAccessControlConfig(ctx context.Context, accessControlConfig *AccessCo
 }
 
 func installIdentities(ctx context.Context, accessControlConfig *AccessControlConfig, cred azcore.TokenCredential) error {
-	serverApp, err := createOrUpdateServerApp(ctx, accessControlConfig, cred)
+	serverApp, initialServerAppBytes, err := createOrUpdateServerApp(ctx, accessControlConfig, cred)
 	if err != nil {
 		return err
 	}
@@ -122,16 +128,27 @@ func installIdentities(ctx context.Context, accessControlConfig *AccessControlCo
 		}
 	}
 
-	if err := addCliAsPreAuthorizedApp(ctx, serverApp, cliApp, cred); err != nil {
+	// Apply the pre-authorized application changes to the in-memory server app, then
+	// reconcile the server app with a single update so the change detection (and its
+	// log message) accounts for these changes as well.
+	if err := addCliAsPreAuthorizedApp(ctx, serverApp, cliApp); err != nil {
 		return fmt.Errorf("failed to add CLI app as pre-authorized app: %w", err)
+	}
+
+	if err := syncAzureCliPreAuthorization(ctx, serverApp, accessControlConfig.EnableAzureCliLogin); err != nil {
+		return fmt.Errorf("failed to update Azure CLI pre-authorization: %w", err)
+	}
+
+	if err := updateServerAppIfChanged(ctx, serverApp, initialServerAppBytes, accessControlConfig.ApiAppUri, cred); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func createOrUpdateServerApp(ctx context.Context, accessControlConfig *AccessControlConfig, cred azcore.TokenCredential) (*aadApp, error) {
+func createOrUpdateServerApp(ctx context.Context, accessControlConfig *AccessControlConfig, cred azcore.TokenCredential) (*aadApp, []byte, error) {
 	if accessControlConfig.ApiAppId == "" && accessControlConfig.ApiAppUri == "" {
-		return nil, errors.New("`apiAppUri` must be set")
+		return nil, nil, errors.New("`apiAppUri` must be set")
 	}
 
 	app, err := GetAppByAppIdOrUri(ctx, cred, accessControlConfig.ApiAppId, accessControlConfig.ApiAppUri)
@@ -142,7 +159,7 @@ func createOrUpdateServerApp(ctx context.Context, accessControlConfig *AccessCon
 				Api:            &aadAppApi{},
 			}
 		} else {
-			return nil, fmt.Errorf("error getting existing server app: %w", err)
+			return nil, nil, fmt.Errorf("error getting existing server app: %w", err)
 		}
 	}
 
@@ -212,25 +229,39 @@ func createOrUpdateServerApp(ctx context.Context, accessControlConfig *AccessCon
 
 	if err == errNotFound {
 		log.Ctx(ctx).Info().Msgf("Creating app %s", accessControlConfig.ApiAppUri)
-		err = executeGraphCall(ctx, cred, http.MethodPost, "https://graph.microsoft.com/beta/applications", app, &app)
-	} else {
-		updatedAppBytes, _ := json.Marshal(app)
-		if string(initialAppBytes) == string(updatedAppBytes) {
-			log.Ctx(ctx).Info().Msgf("No changes detected for app %s, skipping update", accessControlConfig.ApiAppUri)
-		} else {
-			log.Ctx(ctx).Info().Msgf("Updating app %s", accessControlConfig.ApiAppUri)
-			err = executeGraphCall(ctx, cred, http.MethodPatch, fmt.Sprintf("https://graph.microsoft.com/beta/applications/%s", app.Id), app, nil)
+		if err := executeGraphCall(ctx, cred, http.MethodPost, "https://graph.microsoft.com/beta/applications", app, &app); err != nil {
+			return nil, nil, fmt.Errorf("failed to create app: %w", err)
 		}
+		// Use the just-created app as the baseline so that the subsequent reconcile only
+		// detects pre-authorized application changes.
+		initialAppBytes, _ = json.Marshal(app)
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to create or update app: %w", err)
-	}
-
-	return app, nil
+	return app, initialAppBytes, nil
 }
 
-func addCliAsPreAuthorizedApp(ctx context.Context, serverApp, cliApp *aadApp, cred azcore.TokenCredential) error {
+// updateServerAppIfChanged patches the server app if it differs from the baseline captured
+// before any in-memory mutations (role/scope and pre-authorized application changes).
+func updateServerAppIfChanged(ctx context.Context, serverApp *aadApp, initialAppBytes []byte, apiAppUri string, cred azcore.TokenCredential) error {
+	updatedAppBytes, _ := json.Marshal(serverApp)
+	if string(initialAppBytes) == string(updatedAppBytes) {
+		log.Ctx(ctx).Info().Msgf("No changes detected for app %s, skipping update", apiAppUri)
+		return nil
+	}
+
+	log.Ctx(ctx).Info().Msgf("Updating app %s", apiAppUri)
+	if err := executeGraphCall(ctx, cred, http.MethodPatch, fmt.Sprintf("https://graph.microsoft.com/beta/applications/%s", serverApp.Id), serverApp, nil); err != nil {
+		return fmt.Errorf("failed to update app: %w", err)
+	}
+
+	return nil
+}
+
+func addCliAsPreAuthorizedApp(ctx context.Context, serverApp, cliApp *aadApp) error {
+	return addPreAuthorizedApp(ctx, serverApp, cliApp.AppId, "CLI")
+}
+
+func addPreAuthorizedApp(ctx context.Context, serverApp *aadApp, preAuthorizedAppId, logLabel string) error {
 	var scopeId string
 	if scopeIndex := slices.IndexFunc(serverApp.Api.Oauth2PermissionScopes, func(scope *aadAppAuth2PermissionScope) bool {
 		return scope.Value == permissionScopeValue
@@ -242,12 +273,12 @@ func addCliAsPreAuthorizedApp(ctx context.Context, serverApp, cliApp *aadApp, cr
 
 	var preauthorizedApp *aadAppPreAuthorizedApplication
 	if idx := slices.IndexFunc(serverApp.Api.PreAuthorizedApplications, func(app *aadAppPreAuthorizedApplication) bool {
-		return app.AppId == cliApp.AppId
+		return app.AppId == preAuthorizedAppId
 	}); idx != -1 {
 		preauthorizedApp = serverApp.Api.PreAuthorizedApplications[idx]
 	} else {
 		preauthorizedApp = &aadAppPreAuthorizedApplication{
-			AppId:         cliApp.AppId,
+			AppId:         preAuthorizedAppId,
 			PermissionIds: []string{},
 		}
 		serverApp.Api.PreAuthorizedApplications = append(serverApp.Api.PreAuthorizedApplications, preauthorizedApp)
@@ -255,14 +286,31 @@ func addCliAsPreAuthorizedApp(ctx context.Context, serverApp, cliApp *aadApp, cr
 
 	if slices.Index(preauthorizedApp.PermissionIds, scopeId) == -1 {
 		preauthorizedApp.PermissionIds = append(preauthorizedApp.PermissionIds, scopeId)
-		log.Ctx(ctx).Info().Msgf("Adding CLI app %s as pre-authorized app for server app %s", cliApp.AppId, serverApp.AppId)
-		err := executeGraphCall(ctx, cred, http.MethodPatch, fmt.Sprintf("https://graph.microsoft.com/beta/applications/%s", serverApp.Id), serverApp, nil)
-		if err != nil {
-			return fmt.Errorf("failed to add CLI app as pre-authorized app: %w", err)
-		}
+		log.Ctx(ctx).Info().Msgf("Adding %s app %s as pre-authorized app for server app %s", logLabel, preAuthorizedAppId, serverApp.AppId)
 	}
 
 	return nil
+}
+
+func removePreAuthorizedApp(ctx context.Context, serverApp *aadApp, preAuthorizedAppId, logLabel string) error {
+	idx := slices.IndexFunc(serverApp.Api.PreAuthorizedApplications, func(app *aadAppPreAuthorizedApplication) bool {
+		return app.AppId == preAuthorizedAppId
+	})
+	if idx == -1 {
+		return nil
+	}
+
+	serverApp.Api.PreAuthorizedApplications = slices.Delete(serverApp.Api.PreAuthorizedApplications, idx, idx+1)
+	log.Ctx(ctx).Info().Msgf("Removing %s app %s from pre-authorized apps for server app %s", logLabel, preAuthorizedAppId, serverApp.AppId)
+
+	return nil
+}
+
+func syncAzureCliPreAuthorization(ctx context.Context, serverApp *aadApp, enable bool) error {
+	if enable {
+		return addPreAuthorizedApp(ctx, serverApp, azureCliAppId, "Azure CLI")
+	}
+	return removePreAuthorizedApp(ctx, serverApp, azureCliAppId, "Azure CLI")
 }
 
 func createOrUpdateCliApp(ctx context.Context, accessControlConfig *AccessControlConfig, serverApp *aadApp, cred azcore.TokenCredential) (*aadApp, error) {

--- a/cli/internal/install/cloudinstall/cloudconfig.go
+++ b/cli/internal/install/cloudinstall/cloudconfig.go
@@ -311,6 +311,7 @@ type AccessControlConfig struct {
 	CliAppUri                  string                    `yaml:"cliAppUri"`
 	CliAppId                   string                    `yaml:"cliAppId"`
 	ServiceManagementReference string                    `yaml:"serviceManagementReference,omitempty"`
+	EnableAzureCliLogin        bool                      `yaml:"enableAzureCliLogin,omitempty"`
 	RoleAssignments            *TygerRbacRoleAssignments `yaml:"roleAssignments"`
 }
 
@@ -425,9 +426,10 @@ func RenderConfig(templateValues ConfigTemplateValues, writer io.Writer) error {
 					TlsCertificateProvider: TlsCertificateProviderLetsEncrypt,
 					AccessControl: &OrganizationAccessControlConfig{
 						AccessControlConfig: AccessControlConfig{
-							TenantID:  templateValues.OrganizationTenantId,
-							ApiAppUri: "api://tyger-server",
-							CliAppUri: "api://tyger-cli",
+							TenantID:            templateValues.OrganizationTenantId,
+							ApiAppUri:           "api://tyger-server",
+							CliAppUri:           "api://tyger-cli",
+							EnableAzureCliLogin: true,
 							RoleAssignments: &TygerRbacRoleAssignments{
 								Owner: []TygerRbacRoleAssignment{
 									{

--- a/deploy/config/microsoft/accesscontrol-legacy-org.yml
+++ b/deploy/config/microsoft/accesscontrol-legacy-org.yml
@@ -3,8 +3,14 @@ kind: accessControl
 tenantId: 76d3279b-830e-4bea-baf8-12863cdeba4c
 apiAppUri: api://tyger-server
 cliAppUri: api://tyger-cli
+
 apiAppId: e8229c82-a93e-4a2a-a983-d3ed35f2f62c
 cliAppId: f13d0630-3b5f-4a9f-aafa-34bd3bb6062b
+
+# Pre-authorizes the Azure CLI Entra application so that users who are
+# signed in with `az login` can authenticate to Tyger using `tyger login --az`.
+# Users still need to be granted a role below in order to access Tyger.
+enableAzureCliLogin: true
 
 # Principals in role assignments are specified in the following ways:
 #
@@ -23,28 +29,12 @@ cliAppId: f13d0630-3b5f-4a9f-aafa-34bd3bb6062b
 #     objectId: <objectId>
 #     displayName: <displayName>
 
-# Example:
-#
-# roleAssignments:
-#   owner:
-#     - kind: User
-#       objectId: c5e5d858-b954-4bef-b704-71b63e761f69
-#       userPrincipalName: me@example.com
-#
-#     - kind: ServicePrincipal
-#       objectId: 32b73951-e5eb-4a75-8479-23374021f46a
-#       displayName: my-service-principal
-#
-#   contributor:
-#     - kind: Group
-#       objectId: f939c89c-94ed-46b9-8fbd-726cf747f231
-#       displayName: my-group
-
 roleAssignments:
   owner:
     - kind: Group
       objectId: e3a3c857-4dfa-4d73-b23d-3c1d8f6128ff
       displayName: Tyger Owners
+
     - kind: ServicePrincipal
       objectId: 7461b6b1-3b29-4610-935f-e708d52f628e
       displayName: tyger-test-client

--- a/deploy/config/microsoft/cloudconfig-private-link.yml
+++ b/deploy/config/microsoft/cloudconfig-private-link.yml
@@ -214,6 +214,11 @@ organizations:
 
         serviceManagementReference: 7933f882-e109-49d5-a771-e1be70099806
 
+        # Pre-authorizes the Azure CLI Entra application so that users who are
+        # signed in with `az login` can authenticate to Tyger using `tyger login --az`.
+        # Users still need to be granted a role below in order to access Tyger.
+        enableAzureCliLogin: true
+
         # Principals in role assignments are specified in the following ways:
         #
         # For users, specify the object ID and/or the user principal name.

--- a/deploy/config/microsoft/cloudconfig.yml
+++ b/deploy/config/microsoft/cloudconfig.yml
@@ -230,6 +230,11 @@ organizations:
 
         serviceManagementReference: 7933f882-e109-49d5-a771-e1be70099806
 
+        # Pre-authorizes the Azure CLI Entra application so that users who are
+        # signed in with `az login` can authenticate to Tyger using `tyger login --az`.
+        # Users still need to be granted a role below in order to access Tyger.
+        enableAzureCliLogin: true
+
         # Principals in role assignments are specified in the following ways:
         #
         # For users, specify the object ID and/or the user principal name.
@@ -326,6 +331,11 @@ organizations:
 
         apiAppId: e8229c82-a93e-4a2a-a983-d3ed35f2f62c
         cliAppId: f13d0630-3b5f-4a9f-aafa-34bd3bb6062b
+
+        # Pre-authorizes the Azure CLI Entra application so that users who are
+        # signed in with `az login` can authenticate to Tyger using `tyger login --az`.
+        # Users still need to be granted a role below in order to access Tyger.
+        enableAzureCliLogin: false
 
         # Principals in role assignments are specified in the following ways:
         #

--- a/docs/guides/login.md
+++ b/docs/guides/login.md
@@ -70,6 +70,26 @@ You will need to follow GitHub
 [documentation](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-azure)
 in order to ensure you can use this feature from your pipeline.
 
+## Log in using the Azure CLI
+
+If you are already signed in with the [Azure
+CLI](https://learn.microsoft.com/en-us/cli/azure/) (`az`), you can reuse that
+session to acquire a token for Tyger:
+
+```bash
+tyger login SERVER_URL --az
+```
+
+This requires that:
+
+- The Azure CLI is installed and you have run `az login` against the **same
+  tenant** as the Tyger server. If you are signed in to a different tenant, run
+  `az login --tenant TENANT_ID` using the Tyger server's tenant.
+- The operator has enabled Azure CLI login for the deployment by setting
+  `enableAzureCliLogin: true` in the access control configuration and running
+  `tyger access-control apply`. This pre-authorizes the Azure CLI application to
+  access the Tyger API so that no interactive consent prompt is required.
+
 ## Specifying trusted certificate authority certificates
 
 By default, `tyger` uses the operating system's trusted root CA certificates for
@@ -114,6 +134,12 @@ managedIdentityClientId: # Optionally specify the client ID of the managed ident
 
 # Whether to use GitHub Actions tokens with federated identity for authentication.
 github: false
+
+# Whether to use the Azure CLI ('az') to acquire access tokens.
+# Requires that the Azure CLI is installed, that you are signed in with 'az login' to the
+# same tenant as the Tyger server, and that the operator has set 'enableAzureCliLogin: true'
+# in the Tyger access control config.
+azureCli: false
 
 # If using managed identity or GitHub Actions, specify the client ID of the federated identity to authenticate as.
 targetFederatedIdentity: # Optionally specify a federated identity to authenticate as using the managed identity.

--- a/docs/introduction/installation/cloud-installation.md
+++ b/docs/introduction/installation/cloud-installation.md
@@ -257,6 +257,11 @@ organizations:
         apiAppId: "" # `tyger access-control apply` will fill in this value
         cliAppId: "" # `tyger access-control apply` will fill in this value
 
+        # Pre-authorizes the Azure CLI Entra application so that users who are
+        # signed in with `az login` can authenticate to Tyger using `tyger login --az`.
+        # Users still need to be granted a role below in order to access Tyger.
+        enableAzureCliLogin: true
+
         # Principals in role assignments are specified in the following ways:
         #
         # For users, specify the object ID and/or the user principal name.


### PR DESCRIPTION
Adds a new login mode that lets users authenticate to Tyger by reusing an existing Azure CLI (`az`) session, instead of an interactive browser flow, service principal, managed identity, or GitHub federated credentials.

- New `enableAzureCliLogin` field in the access-control config. When `true`, `tyger access-control apply` pre-authorizes the well-known Azure CLI Entra application on the Tyger API app so no interactive consent is required; when `false` it removes the pre-authorization.
- New `--az` flag on `tyger login` (and the equivalent `azureCli` option in the login options file and `tyger-proxy`). It acquires a token via `azidentity.NewAzureCLICredential`, scoped and tenant-pinned to the Tyger server's authority.
- Added mutual-exclusivity validation so `--az` can't be combined with service principal, managed identity, GitHub, device code, or certificate options.
- Azure CLI credential errors are translated into actionable guidance (CLI not installed, missing pre-authorization, wrong tenant, not signed in), keying off stable AADSTS codes with word-boundary matching.
- This new mode is the default authentication mode for dev containers

NOTE: it unfortunately does not work from the Azure Cloud Shell.

Also adding copilot-instructions.md, a guide that gives GitHub Copilot the context needed to work effectively in this repo.